### PR TITLE
Fix up restart and add POLL_RATE flag.

### DIFF
--- a/adsApp/src/adsAsynPortDriver.cpp
+++ b/adsApp/src/adsAsynPortDriver.cpp
@@ -247,6 +247,7 @@ adsAsynPortDriver::adsAsynPortDriver(const char *portName,
                                      0) /* Default stack size*/
 {
   const char* functionName = "adsAsynPortDriver";
+  //Extra Debugging from the beginning: pasynTrace->setTraceMask(pasynUserSelf, 0x11);
   asynPrint(pasynUserSelf,ASYN_TRACE_FLOW, "%s:%s:\n", driverName, functionName);
 
   pAdsParamArray_= new adsParamInfo*[paramTableSize];
@@ -359,6 +360,7 @@ adsAsynPortDriver::adsAsynPortDriver(const char *portName,
   bulkdatasize = 4 * 1024 * 1024; // This is excessive!
   bulkdata = (uint8_t *) malloc(bulkdatasize);
   bulkOK = 0;
+  bulk_elapsed_us = 0;
 
   //* Create the thread that does the bulk reads */
   status = (asynStatus)(epicsThreadCreate("adsAsynPortDriverBulkReadThread",
@@ -370,8 +372,31 @@ adsAsynPortDriver::adsAsynPortDriver(const char *portName,
     printf("%s:%s: epicsThreadCreate failure\n", driverName, functionName);
     return;
   }
-  //try connect
-  connect(pasynUserSelf);
+  //try to connect, and hang until we succeed!
+  for (;;) {
+      if (connect(pasynUserSelf) != asynSuccess) {
+	  asynPrint(pasynUserSelf, ASYN_TRACE_ERROR, 
+		    "%s:%s: connect failed for port %s.\n", 
+		    driverName, functionName, portName);
+	  epicsThreadSleep(1.0);
+	  continue;
+      }
+      long error = 0;
+      uint16_t adsState = 0;
+      if (adsReadStateLock(amsport,&adsState,true,&error) != asynSuccess) {
+	  asynPrint(pasynUserSelf, ASYN_TRACE_ERROR, 
+		    "%s:%s: adsReadStateLock failed for port %s.\n", 
+		    driverName, functionName, portName);
+	  disconnect(pasynUserSelf);
+	  continue;
+      }
+      if (adsState == ADSSTATE_RUN) {
+	  asynPrint(pasynUserSelf, ASYN_TRACE_ERROR, 
+		    "%s:%s: connection established for port %s.\n", 
+		    driverName, functionName, portName);
+	  return;
+      }
+  }
 }
 
 /** Destructor for the adsAsynPortDriver class.
@@ -457,6 +482,10 @@ void adsAsynPortDriver::cyclicThread()
           invalidateParamsLock(port->amsPort);
           port->refreshNeeded=true;
           setAlarmPortLock(port->amsPort,COMM_ALARM,INVALID_ALARM);
+	  asynPrint(pasynUserSelf, ASYN_TRACE_ERROR, 
+		    "%s:%s: connection failed for port %s.\n", 
+		    driverName, functionName, portName);
+	  exit(-1);
         }
         if(!port->connectedOld && port->connected){
           adsReadVersion(port);
@@ -506,6 +535,7 @@ void adsAsynPortDriver::cyclicThread()
   }
 }
 
+/* TBD - Poll at different rates depending on pollClass! */
 void adsAsynPortDriver::bulkReadThread()
 {
     const char* functionName = "bulkReadThread";
@@ -588,13 +618,13 @@ void adsAsynPortDriver::bulkReadThread()
         }
         adsUnlock();
         gettimeofday(&now, NULL);
-        int us_elapsed = (now.tv_sec - start.tv_sec) * 1000000 + 
-                         (now.tv_usec - start.tv_usec);
+        bulk_elapsed_us = (now.tv_sec - start.tv_sec) * 1000000 + 
+	                  (now.tv_usec - start.tv_usec);
 #ifdef MCB_DEBUG
-        printf("ELAPSED: %g\n", us_elapsed / 1000000.0);
+        printf("ELAPSED: %g\n", bulk_elapsed_us / 1000000.0);
 #endif
-        if (us_elapsed < bulk_delay_us) {
-            usleep(bulk_delay_us - us_elapsed);
+        if (bulk_elapsed_us < bulk_delay_us) {
+            usleep(bulk_delay_us - bulk_elapsed_us);
             gettimeofday(&now, NULL);
         }
     }
@@ -844,7 +874,7 @@ asynStatus adsAsynPortDriver::connectLock(asynUser *pasynUser)
 asynStatus adsAsynPortDriver::connect(asynUser *pasynUser)
 {
   const char* functionName = "connect";
-  asynPrint(pasynUser, ASYN_TRACE_FLOW, "%s:%s:\n", driverName, functionName);
+  asynPrint(pasynUser, ASYN_TRACE_FLOW, "%s:%s: %s\n", driverName, functionName, epicsThreadGetNameSelf());
 
   bool err=false;
   asynStatus stat = adsConnect();
@@ -1099,15 +1129,15 @@ asynStatus adsAsynPortDriver::updateParamInfoWithPLCInfo(adsParamInfo *paramInfo
   }
 
   if(paramInfo->isIOIntr){
-      /* If we specify a sample rate or it's big, just subscribe to it! */
-      if (paramInfo->hasSampleRate || paramInfo->plcSize > 1024*1024) {
+      /* If it's not a bulk read or if it's really big, just subscribe to it! */
+      if (!paramInfo->isBulkRead || paramInfo->plcSize > 1024*1024) {
           adsDelDataCallback(paramInfo,true);   //try to delete
           status=adsAddDataCallback(paramInfo);
           if(status!=asynSuccess){
               return asynError;
           }
       } else { /* Otherwise, put it in a bulk read! */
-          status=adsAddToBulkRead(paramInfo);
+	  status=adsAddToBulkRead(paramInfo);
           if(status!=asynSuccess){
               return asynError;
           }
@@ -1130,6 +1160,35 @@ asynStatus adsAsynPortDriver::updateParamInfoWithPLCInfo(adsParamInfo *paramInfo
   return asynSuccess;
 }
 
+void adsAsynPortDriver::poll_info(char *name)
+{
+    int i;
+    printf("Bulk read loop: desired period = %gs, last loop time = %gs\n", bulk_delay_us / 1000000.0, bulk_elapsed_us / 1000000.0);
+    for (i = 0; bulk[i].cnt && i < MAXBULK; i++);
+    printf("Bulk read count = %d\n", i);
+    if (name[0] == 0)
+        name = 0;
+    for (i = 0; bulk[i].cnt && i < MAXBULK; i++) {
+      printf("Bulk Read #%d:\n", i);
+      if (!name) {
+	  printf("    0: MAIN.fbSystemTime.timeLoDW (G=0x%x, O=0x%x, S=%d)\n",
+		 bulk[i].sum[0].iGroup, bulk[i].sum[0].iOffset, bulk[i].sum[0].iSize);
+	  printf("    1: MAIN.fbSystemTime.timeHiDW (G=0x%x, O=0x%x, S=%d)\n",
+		 bulk[i].sum[1].iGroup, bulk[i].sum[1].iOffset, bulk[i].sum[1].iSize);
+      }
+      for (int j = 2; j < bulk[i].cnt; j++) {
+        adsParamInfo *paramInfo=getAdsParamInfo(bulk[i].paramID[j]);
+	if (!paramInfo)
+	  continue;
+	if (!name || strstr(paramInfo->plcAdrStr, name))
+	    printf("  %3d: %s (G=0x%x, O=0x%x, S=%d, TS=%d.%09d)\n", j, paramInfo->plcAdrStr,
+		   bulk[i].sum[j].iGroup, bulk[i].sum[j].iOffset, bulk[i].sum[j].iSize,
+		   paramInfo->epicsTimestamp.secPastEpoch, paramInfo->epicsTimestamp.nsec);
+      }
+    }
+}
+
+/* TBD - Use paramInfo->pollClass to separate into different poll rates!! */
 asynStatus adsAsynPortDriver::adsAddToBulkRead(adsParamInfo* paramInfo)
 {
     adsLock(); // Prevent reads while we change this!
@@ -1441,7 +1500,6 @@ asynStatus adsAsynPortDriver::parsePlcInfofromDrvInfo(const char* drvInfo,adsPar
   //Check if ADS_OPTION_T_SAMPLE_RATE_MS option
   option=ADS_OPTION_T_SAMPLE_RATE_MS;
   paramInfo->sampleTimeMS=defaultSampleTimeMS_;
-  paramInfo->hasSampleRate = false;
   isThere=strstr(drvInfo,option);
   if(isThere){
     if(strlen(isThere)<(strlen(option)+strlen("=0/"))){
@@ -1456,7 +1514,27 @@ asynStatus adsAsynPortDriver::parsePlcInfofromDrvInfo(const char* drvInfo,adsPar
       asynPrint(pasynUserSelf, ASYN_TRACE_ERROR, "%s:%s: Failed to parse %s option from drvInfo (%s). Wrong format.\n", driverName, functionName,option,drvInfo);
       return asynError;
     }
-    paramInfo->hasSampleRate = true;
+  }
+
+  //Check if ADS_OPTION_POLLRATE option
+  option=ADS_OPTION_POLLRATE;
+  paramInfo->isBulkRead = false;
+  paramInfo->pollClass = 1.0;
+  isThere=strstr(drvInfo,option);
+  if(isThere){
+    if(strlen(isThere)<(strlen(option)+strlen("=0/"))){
+      asynPrint(pasynUserSelf, ASYN_TRACE_ERROR, "%s:%s: Failed to parse %s option from drvInfo (%s). String to short.\n", driverName, functionName,option,drvInfo);
+      return asynError;
+    }
+    paramInfo->isBulkRead = true;
+
+    int nvals = sscanf(isThere+strlen(option),"=%lf/",&paramInfo->pollClass);
+
+    if(nvals!=1){
+      paramInfo->pollClass = 1.0;
+      asynPrint(pasynUserSelf, ASYN_TRACE_ERROR, "%s:%s: Failed to parse %s option from drvInfo (%s). Wrong format.\n", driverName, functionName,option,drvInfo);
+      return asynError;
+    }
   }
 
   //Check if ADS_OPTION_TIMEBASE option
@@ -3140,6 +3218,12 @@ asynStatus adsAsynPortDriver::adsGetSymInfoByName(uint16_t amsPort,const char *v
 
   if (infoStatus) {
     asynPrint(pasynUserSelf, ASYN_TRACE_ERROR, "%s:%s: Get symbolic information failed for %s with: %s (0x%lx)\n", driverName, functionName,varName,adsErrorToString(infoStatus),infoStatus);
+    if (infoStatus == GLOBALERR_TARGET_PORT) {
+	/* Sigh.  It was up, now it's down.  Let's go home. */
+	asynPrint(pasynUserSelf, ASYN_TRACE_ERROR, "%s:%s: Port error, giving up!\n", 
+		  driverName, functionName);
+	exit(1);
+    }
     return asynError;
   }
 
@@ -3211,7 +3295,6 @@ asynStatus adsAsynPortDriver::adsConnect()
   const char* functionName = "adsConnect";
   asynPrint(pasynUserSelf,ASYN_TRACE_FLOW, "%s:%s:\n", driverName, functionName);
 
-
   adsDelRoute(1);
   // add local route to your ADS Master
   if(!routeAdded_){
@@ -3219,18 +3302,26 @@ asynStatus adsAsynPortDriver::adsConnect()
 
     if (stat!=asynSuccess) {
       adsDelRoute(1);
-      adsPort_=0;
-      return asynError;
+      if (adsPort_) {
+	  adsLock();
+	  AdsPortCloseEx(adsPort_);
+	  adsPort_=0;
+	  adsUnlock();
+	  return asynError;
+      }
     }
   }
+
   // open a new ADS port
   adsLock();
-  adsPort_ = AdsPortOpenEx();
+  if (!adsPort_)
+      adsPort_ = AdsPortOpenEx();
   adsUnlock();
   if (!adsPort_) {
     asynPrint(pasynUserSelf, ASYN_TRACE_ERROR, "%s:%s:Open ADS port failed.\n", driverName, functionName);
     return asynError;
   }
+  asynPrint(pasynUserSelf, ASYN_TRACE_FLOW, "%s:%s:Open ADS port = %ld.\n", driverName, functionName, adsPort_);
   // Update timeout
   uint32_t defaultTimeout=0;
   adsLock();
@@ -3287,17 +3378,16 @@ asynStatus adsAsynPortDriver::adsReadVersion(amsPortInfo *port)
 asynStatus adsAsynPortDriver::adsDisconnect()
 {
   const char* functionName = "adsDisconnect";
-  asynPrint(pasynUserSelf,ASYN_TRACE_FLOW, "%s:%s:\n", driverName, functionName);
+  asynPrint(pasynUserSelf,ASYN_TRACE_FLOW, "%s:%s: adsPort_=%ld\n", driverName, functionName, adsPort_);
 
   adsLock();
   const long closeStatus = AdsPortCloseEx(adsPort_);
+  adsPort_ = 0;
   adsUnlock();
   if (closeStatus) {
     asynPrint(pasynUserSelf, ASYN_TRACE_ERROR, "%s:%s: Close ADS port failed with: %s (0x%lx)\n", driverName, functionName,adsErrorToString(closeStatus),closeStatus);
     return asynError;
   }
-
-  adsPort_=0;
 
   return asynSuccess;
 }
@@ -4377,7 +4467,7 @@ asynStatus adsAsynPortDriver::adsAddRouteLock()
 
   // add local route to your ADS Master
   adsLock();
-  const long addRouteStatus =AdsAddRoute(remoteNetId_, ipaddr_);
+  const long addRouteStatus = AdsAddRoute(remoteNetId_, ipaddr_);
   adsUnlock();
   if(addRouteStatus){
     asynPrint(pasynUserSelf, ASYN_TRACE_ERROR, "%s:%s: Adding ADS route failed with: %s (0x%lx).\n", driverName, functionName,adsErrorToString(addRouteStatus),addRouteStatus);
@@ -4572,6 +4662,18 @@ extern "C" {
   }
 
   /*
+   * adsPollInfo("name")
+   */
+  static const iocshArg adsPollInfoArg0 = {"name", iocshArgString};
+  static const iocshArg *adsPollInfoArgs[] = {&adsPollInfoArg0};
+  static const iocshFuncDef adsPollInfoFuncDef = {"adsPollInfo",1,adsPollInfoArgs};
+
+  static void adsPollInfoCallFunc(const iocshArgBuf *args)
+  {
+    adsAsynPortObj->poll_info(args[0].sval);
+  }
+
+  /*
    * This routine is called before multitasking has started, so there's
    * no race condition in the test/set of firstTime.
    */
@@ -4580,6 +4682,7 @@ extern "C" {
   {
     iocshRegister(&adsAsynPortDriverConfigureFuncDef,adsAsynPortDriverConfigureCallFunc);
     iocshRegister(&adsSetLocalAddressFuncDef,adsSetLocalAddressCallFunc);
+    iocshRegister(&adsPollInfoFuncDef, adsPollInfoCallFunc);
   }
 
   epicsExportRegistrar(adsAsynPortDriverRegister);

--- a/adsApp/src/adsAsynPortDriver.h
+++ b/adsApp/src/adsAsynPortDriver.h
@@ -99,6 +99,7 @@ public:
 
   void cyclicThread();
   void bulkReadThread();
+  void poll_info(char *name);
 protected:
 
 private:
@@ -276,6 +277,7 @@ private:
   int bulkdatasize;          // Size of the read buffer.
  public:
   int bulkOK;                // OK to process bulk reads!
+  int bulk_elapsed_us;       // Time of last bulk read loop.
 };
 
 #endif /* ADSASYNPORTDRIVER_H_ */

--- a/adsApp/src/adsAsynPortDriverUtils.h
+++ b/adsApp/src/adsAsynPortDriverUtils.h
@@ -27,6 +27,7 @@
 #define ADS_OPTION_T_MAX_DLY_MS "T_DLY_MS"
 #define ADS_OPTION_T_SAMPLE_RATE_MS "TS_MS"
 #define ADS_OPTION_TIMEBASE "TIMEBASE"  //PLC or EPICS
+#define ADS_OPTION_POLLRATE "POLL_RATE"
 #define ADS_OPTION_TIMEBASE_EPICS "EPICS"
 #define ADS_OPTION_TIMEBASE_PLC "PLC"
 #define ADS_OPTION_ADSPORT "ADSPORT"
@@ -66,7 +67,8 @@ typedef struct adsParamInfo{
   int            paramIndex;  //also used as hUser for ads callback
   bool           plcAbsAdrValid;  //Symbolic address converted to abs address or .ADR. command parsed
   bool           isAdrCommand;
-  bool           hasSampleRate;
+  bool           isBulkRead;
+  double         pollClass;
   char           *plcAdrStr;
   uint32_t       plcAbsAdrGroup;
   uint32_t       plcAbsAdrOffset;


### PR DESCRIPTION
Two changes:

- A PLC variable can have a POLL_RATE flag which specifies the poll rate in ms.  By default, this is ignored, but we could, in theory, use it to create several classes of PLC variables which are read back at different rates.
- Much improved startup handling.  If the PLC and IOC don't agree, we exit and allow them to properly resynchronize.