### PR TITLE
ENH: open a local port when the IP address is localhost-like

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "ADS"]
 	path = ADS
-	url = /afs/slac.stanford.edu/g/cd/swe/git/repos/package/epics/modules/ADS.git
+	url = https://github.com/pcdshub/ADS
 	branch = github-master
 [submodule "TwinCATexample"]
 	path = TwinCATexample

--- a/adsApp/src/Makefile
+++ b/adsApp/src/Makefile
@@ -6,7 +6,7 @@ include $(TOP)/configure/CONFIG
 #=============================
 
 USR_CXXFLAGS += -std=c++11
-USR_CPPFLAGS += -I ../../../ADS/AdsLib/
+USR_CPPFLAGS += -I $(TOP)/ADS/AdsLib/
 USR_LDFLAGS  += -lpthread
 
 #=============================

--- a/adsApp/src/adsAsynPortDriver.cpp
+++ b/adsApp/src/adsAsynPortDriver.cpp
@@ -3316,8 +3316,17 @@ asynStatus adsAsynPortDriver::adsConnect()
 
   // open a new ADS port
   adsLock();
-  if (!adsPort_)
-      adsPort_ = AdsPortOpenEx();
+  if (!adsPort_) {
+    if (!strcmp(ipaddr_, "127.0.0.1") || !strcmp(ipaddr_, "localhost")) {
+        asynPrint(pasynUserSelf, ASYN_TRACE_WARNING, "%s:%s:Opening a special ADS port on localhost.\n", driverName, functionName);
+        if (!AdsPortOpenLocalEx(adsPort_)) {
+            asynPrint(pasynUserSelf, ASYN_TRACE_ERROR, "%s:%s:Open localhost ADS port failed.\n", driverName, functionName);
+            return asynError;
+        }
+    } else {
+        adsPort_ = AdsPortOpenEx();
+    }
+  }
   adsUnlock();
   if (!adsPort_) {
     asynPrint(pasynUserSelf, ASYN_TRACE_ERROR, "%s:%s:Open ADS port failed.\n", driverName, functionName);

--- a/adsApp/src/adsAsynPortDriver.h
+++ b/adsApp/src/adsAsynPortDriver.h
@@ -232,7 +232,7 @@ private:
   int                            defaultMaxDelayTimeMS_;
   int                            adsTimeoutMS_;
   int                            connectedAds_;
-  long                           adsPort_;
+  uint16_t                       adsPort_;
   int                            routeAdded_;
   int                            notConnectedCounter_;
   int                            oneAmsConnectionOKold_;


### PR DESCRIPTION
## Context
Pairs with:
* https://github.com/pcdshub/ADS/pull/1

## Example run

With an unmodified rhel7-x86_64 (Linux) ads-ioc binary compiled based on this PR, running a TwinCAT BSD VM with the LinuxEmu layer enabled, to successfully communicate with localhost and serve PVs.

The startup looked like this:

```
2023-10-26T02:53:22+0000 Info: Connected to 127.0.0.1
2023-10-26T02:53:22+0000 Info: Requesting a port on localhost...
2023-10-26T02:53:22+0000 Info: Automatically added a localhost route
Our address according to the server is: 192.168.2.193.1.1 with port 32938
```

With a simple database:

```
[TCBSD: RUN] [Administrator@test-plc-01  ioc-pytmc-simple-plc]$ cat pytmc_simple_plc.db
record(longin, "PLC:TEST:iCount_RBV") {
  field(DESC, "MAIN.iCount")
  field(SCAN, "I/O Intr")
  field(PINI, "1")
  field(TSE, "-2")
  field(DTYP, "asynInt32")
  field(INP, "@asyn($(PORT),0,1)ADSPORT=851/POLL_RATE=1/MAIN.iCount?")
  info(autosaveFields_pass0, "DESC DISS HHSV HIGH HIHI HSV LLSV LOLO LOW LSV SIMS UDFS")
  info(archive, "VAL")
}
```

And then camonitor:

```
PLC:TEST:iCount_RBV            2023-10-25 20:41:26.743282 14658
PLC:TEST:iCount_RBV            2023-10-25 20:41:27.754594 14771
PLC:TEST:iCount_RBV            2023-10-25 20:41:28.764329 14883
```