### PR TITLE
Added exit(1) call when a bulk read failure is detected.

### DIFF
--- a/adsApp/src/adsAsynPortDriver.cpp
+++ b/adsApp/src/adsAsynPortDriver.cpp
@@ -608,7 +608,7 @@ void adsAsynPortDriver::bulkReadThread()
                     asynPrint(asynTraceUser, ASYN_TRACE_ERROR,
                               "%s:%s: bulk read for %s (%d) failed\n",
                               driverName, functionName, paramInfo->drvInfo, j);
-                    continue;
+                    exit(1);
                 }
                 paramInfo->plcTimeStampRaw=nTimeStamp;
                 paramInfo->lastCallbackSize=paramInfo->plcSize;


### PR DESCRIPTION
Jira ticket https://jira.slac.stanford.edu/browse/ECS-5034

When an ads-ioc bulk read failure is detected the `continue()` statement in line 607 of adsAsynPortDriver.cpp (https://github.com/janeliu-slac/twincat-ads/blob/R2.0.0-0.branch/adsApp/src/adsAsynPortDriver.cpp) causes the bulk read failure message to repeat indefinitely in the console. This fix replaces `continue()` with `exit()` to break out of the loop and restart the ioc. 

I tested this a bunch of times and the console output shows that the bulk read failure message shows up only once before the ioc restarts:
<img width="1261" alt="ecs-5034_successful_test" src="https://github.com/user-attachments/assets/66dfcbfa-7292-4305-8bad-a635d8a8958e">

Also working on what's causing the bulk read failures.