### PR TITLE
Build against asyn R4.39-1.0.2

### DIFF
--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -2,6 +2,10 @@
 # SLAC Release notes for twincat-ads EPICS module
 #
 
+R2.0.0-0.0.3:	2024-10-14 Jeremy Lorelli
+	Update to asyn/R4.39-1.0.2
+	Bumped ADS submodule revision to fix Rocky 9 build issue
+
 R2.0.0-0.0.2:	2019-06-11 Bruce Hill
 	Update to asyn/R4.35-0.0.1
 

--- a/configure/RELEASE.local
+++ b/configure/RELEASE.local
@@ -15,7 +15,7 @@
 # Define the version of modules needed by
 # IOC apps or other Support apps
 # ===============================================================
-ASYN_MODULE_VERSION = R4.35-0.0.1
+ASYN_MODULE_VERSION = R4.39-1.0.2
 #AXIS_MODULE_VERSION = R0.0.1
 
 # ==========================================================


### PR DESCRIPTION
Build against asyn R4.39-1.0.2 for rhel8+ support

Additionally, the ADS submodule will have to be bumped once https://github.com/pcdshub/ADS/pull/2 is merged. 