### PR TITLE
FIX: notify race condition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,4 +19,4 @@ lib/
 TwinCAT/demo_project/MCAG_Base_Project/_Boot*
 TwinCAT/demo_project/MCAG_Base_Project/_Configure*
 TwinCAT/demo_project/MCAG_Base_Project/MCAG_PLC_Project/_CompileInfo*
-
+.vscode

--- a/adsApp/src/adsAsynPortDriver.cpp
+++ b/adsApp/src/adsAsynPortDriver.cpp
@@ -132,6 +132,12 @@ static void adsSymbolsChangedCallback(const AmsAddr* pAddr, const AdsNotificatio
  */
 static void adsDataCallback(const AmsAddr* pAddr, const AdsNotificationHeader* pNotification, uint32_t hUser)
 {
+  /* We need to skip this when it fires too early.
+  * See https://github.com/pcdshub/twincat-ads/pull/17 for a full explanation
+  * In short: this is run on the io processing loop and it acquires a lock,
+  * so this can break IOC initialization if the lock takes more than 1s to acquire.
+  * We'll catch up later by calling fireAllCallbacksLock once (see getEpicsState).
+  */
   if (!allowCallbackEpicsState) {
     return;
   }

--- a/adsApp/src/adsAsynPortDriver.cpp
+++ b/adsApp/src/adsAsynPortDriver.cpp
@@ -132,6 +132,9 @@ static void adsSymbolsChangedCallback(const AmsAddr* pAddr, const AdsNotificatio
  */
 static void adsDataCallback(const AmsAddr* pAddr, const AdsNotificationHeader* pNotification, uint32_t hUser)
 {
+  if (!allowCallbackEpicsState) {
+    return;
+  }
   const char* functionName = "adsDataCallback";
 
   if(!adsAsynPortObj){


### PR DESCRIPTION
## Motivation

This fixes the core issue found while testing https://github.com/pcdshub/ioc-common-ads-ioc/pull/105, which was that many of the PVs could not be initialized at startup, giving a sync timeout error. This increased startup time by a large amount and left us with many non-functional PVs. After this PR, the IOC in https://github.com/pcdshub/lcls-plc-tst-ioc/pull/1 works great on rhel7 and on rocky9 (with some additional minor fixes needed, but not in this module).

## Short Explanation

There was a race condition in the IO processing queue that caused a slow operation during startup. This is now skipped.

## Long Explanation

The ADS library used here to communicate with the PLC creates a TCP connection to the PLC and reads all incoming packets in a loop: https://github.com/pcdshub/ADS/blob/bd1d62a9da2d3815f84110f148adef7e0d71efa6/AdsLib/AmsConnection.cpp#L312-L358

This loop interprets the incoming packets in the order they arrive and makes sure the client code gets the data that it is interested in using.

Client code like the code in `twincat-ads` can do one of a few main categories of things:

- Request a read (e.g. get the data at an address)
- Request a read-write (e.g. what's the value of this symbol name)
- Register a callback (run my code when a value changes)

The problem arises because the callback necessarily runs in the same loop as the IO processing. So, if a callback takes a long time, the loop will temporarily stop reading the incoming packets.

If another bit of user code requests e.g. a synchronous read or a read-write while a long callback is running, the response will not arrive in a timely manner, causing timeouts and other issues.

Here, we have a callback for updating PV data that asks to acquire an asyn lock. For whatever reason, this now runs during startup and acquiring the lock takes upwards of 5-10 seconds. During this span, 5-10 PVs will fail to initialize with 1s timeouts.

https://github.com/pcdshub/twincat-ads/blob/afbc61493bd8758d5ac9ac3270778b18b6ecfa2d/adsApp/src/adsAsynPortDriver.cpp#L133

Ultimately, there are other reasons to not run these callbacks during startup. There's a bit of code later after acquiring the lock that skips the important part of the processing.

Since we skip the update, why not skip the whole thing altogether?

After startup, the IOC goes back to fire any callbacks that got skipped during startup.

https://github.com/pcdshub/twincat-ads/blob/afbc61493bd8758d5ac9ac3270778b18b6ecfa2d/adsApp/src/adsAsynPortDriver.cpp#L83

## Possible Root Causes?

- Perhaps these notify events were not received so early in previous versions of asyn/epics?
- Perhaps in previous versions of asyn/epics, some other process didn't initialize so early, meaning that acquiring the lock was quick?

## Other thoughts

Probably we shouldn't be acquiring locks in the IO loop at all, and instead we should be spawning a thread.