### PR TITLE
FIX: instability related to rocky9 update

### DIFF
--- a/adsApp/src/adsAsynPortDriver.cpp
+++ b/adsApp/src/adsAsynPortDriver.cpp
@@ -140,6 +140,7 @@ static void adsDataCallback(const AmsAddr* pAddr, const AdsNotificationHeader* p
   }
 
   asynUser *asynTraceUser=adsAsynPortObj->getTraceAsynUser();
+  asynPrint(asynTraceUser,ASYN_TRACE_FLOW, "%s:%s:\n", driverName, functionName);
   asynPrint(asynTraceUser, ASYN_TRACEIO_DRIVER , "%s:%s:\n", driverName, functionName);
 
   const uint8_t* data = reinterpret_cast<const uint8_t*>(pNotification + 1);
@@ -164,8 +165,12 @@ static void adsDataCallback(const AmsAddr* pAddr, const AdsNotificationHeader* p
     asynPrint(asynTraceUser, ASYN_TRACE_ERROR, "%s:%s: getAdsParamInfo() for hUser %u failed\n", driverName, functionName,hUser);
     return;
   }
+  if (adsAsynPortObj->datacbqueue.size() > MAXCBQSIZE) {
+    asynPrint(asynTraceUser, ASYN_TRACE_ERROR, "%s:%s: datacbqueue at max size, skip %s (%d)\n", driverName, functionName,paramInfo->drvInfo,paramInfo->paramIndex);
+    return;
+  }
 
-  asynPrint(asynTraceUser, ASYN_TRACEIO_DRIVER,"Callback for parameter %s (%d).\n",paramInfo->drvInfo,paramInfo->paramIndex);
+  asynPrint(asynTraceUser, ASYN_TRACEIO_DRIVER,"Process callback for parameter %s (%d).\n",paramInfo->drvInfo,paramInfo->paramIndex);
   asynPrint(asynTraceUser, ASYN_TRACEIO_DRIVER,"hUser 0x%x, data size[b]: %d.\n", hUser,pNotification->cbSampleSize);
   asynPrint(asynTraceUser, ASYN_TRACEIO_DRIVER,"time stamp [100ns]: %ld, since last plc [ms]: %4.2lf, since last ioc [ms]: %4.2lf.\n",
             pNotification->nTimeStamp,((double)(pNotification->nTimeStamp-oldTimeStamp))/10000.0,(((double)(micros_used))/1000.0));
@@ -177,7 +182,8 @@ static void adsDataCallback(const AmsAddr* pAddr, const AdsNotificationHeader* p
     return;
   }
 
-  // Copy data into memory here so the ADS Recv queue can deallocate it
+  // Copy data into memory here because the data pointer will not stay valid forever
+  // This malloc is freed in dataCallbackThread
   void* local_data = malloc(pNotification->cbSampleSize);
   memcpy(local_data, data, pNotification->cbSampleSize);
   adsAsynPortDriver::datacbinfo cbinfo = {paramInfo, local_data, *pNotification};
@@ -659,16 +665,21 @@ void adsAsynPortDriver::bulkReadThread()
 /* Keeps possible slow data callbacks off of the ADS Recv queue*/
 void adsAsynPortDriver::dataCallbackThread()
 {
+    const char* functionName = "dataCallbackThread";
+    asynPrint(pasynUserSelf,ASYN_TRACE_FLOW, "%s:%s:\n", driverName, functionName);
     while (1) {
         if (datacbqueue.empty() || !allowCallbackEpicsState) {
             usleep(10000);
             continue;
         }
         adsAsynPortDriver::datacbinfo* info = &datacbqueue.front();
+        asynPrint(pasynUserSelf, ASYN_TRACEIO_DRIVER,"%s:%s: Callback queue has %ld elements\n", driverName, functionName, datacbqueue.size());
+        asynPrint(pasynUserSelf, ASYN_TRACEIO_DRIVER,"%s:%s: Run callback for parameter %s (%d).\n", driverName, functionName, info->paramInfo->drvInfo,info->paramInfo->paramIndex);
         info->paramInfo->plcTimeStampRaw = info->pNotification.nTimeStamp;
         info->paramInfo->lastCallbackSize = info->pNotification.cbSampleSize;
         adsUpdateParameterLock(info->paramInfo, info->data);
         datacbqueue.pop();
+        // This free is for the malloc in adsDataCallback
         free(info->data);
     }
 }

--- a/adsApp/src/adsAsynPortDriver.cpp
+++ b/adsApp/src/adsAsynPortDriver.cpp
@@ -140,7 +140,7 @@ static void adsDataCallback(const AmsAddr* pAddr, const AdsNotificationHeader* p
   }
 
   asynUser *asynTraceUser=adsAsynPortObj->getTraceAsynUser();
-  asynPrint(asynTraceUser,ASYN_TRACE_FLOW, "%s:%s:\n", driverName, functionName);
+  asynPrint(asynTraceUser, ASYN_TRACE_FLOW, "%s:%s:\n", driverName, functionName);
   asynPrint(asynTraceUser, ASYN_TRACEIO_DRIVER , "%s:%s:\n", driverName, functionName);
 
   const uint8_t* data = reinterpret_cast<const uint8_t*>(pNotification + 1);
@@ -165,8 +165,8 @@ static void adsDataCallback(const AmsAddr* pAddr, const AdsNotificationHeader* p
     asynPrint(asynTraceUser, ASYN_TRACE_ERROR, "%s:%s: getAdsParamInfo() for hUser %u failed\n", driverName, functionName,hUser);
     return;
   }
-  if (adsAsynPortObj->datacbqueue.size() > MAXCBQSIZE) {
-    asynPrint(asynTraceUser, ASYN_TRACE_ERROR, "%s:%s: datacbqueue at max size, skip %s (%d)\n", driverName, functionName,paramInfo->drvInfo,paramInfo->paramIndex);
+  if(adsAsynPortObj->datacbqueue.size() > MAXCBQSIZE){
+    asynPrint(asynTraceUser, ASYN_TRACE_ERROR, "%s:%s: datacbqueue at max size, skip %s (%d)\n", driverName, functionName, paramInfo->drvInfo, paramInfo->paramIndex);
     return;
   }
 
@@ -674,7 +674,7 @@ void adsAsynPortDriver::dataCallbackThread()
         }
         adsAsynPortDriver::datacbinfo* info = &datacbqueue.front();
         asynPrint(pasynUserSelf, ASYN_TRACEIO_DRIVER,"%s:%s: Callback queue has %ld elements\n", driverName, functionName, datacbqueue.size());
-        asynPrint(pasynUserSelf, ASYN_TRACEIO_DRIVER,"%s:%s: Run callback for parameter %s (%d).\n", driverName, functionName, info->paramInfo->drvInfo,info->paramInfo->paramIndex);
+        asynPrint(pasynUserSelf, ASYN_TRACEIO_DRIVER,"%s:%s: Run callback for parameter %s (%d).\n", driverName, functionName, info->paramInfo->drvInfo, info->paramInfo->paramIndex);
         info->paramInfo->plcTimeStampRaw = info->pNotification.nTimeStamp;
         info->paramInfo->lastCallbackSize = info->pNotification.cbSampleSize;
         adsUpdateParameterLock(info->paramInfo, info->data);

--- a/adsApp/src/adsAsynPortDriver.cpp
+++ b/adsApp/src/adsAsynPortDriver.cpp
@@ -132,15 +132,6 @@ static void adsSymbolsChangedCallback(const AmsAddr* pAddr, const AdsNotificatio
  */
 static void adsDataCallback(const AmsAddr* pAddr, const AdsNotificationHeader* pNotification, uint32_t hUser)
 {
-  /* We need to skip this when it fires too early.
-  * See https://github.com/pcdshub/twincat-ads/pull/17 for a full explanation
-  * In short: this is run on the io processing loop and it acquires a lock,
-  * so this can break IOC initialization if the lock takes more than 1s to acquire.
-  * We'll catch up later by calling fireAllCallbacksLock once (see getEpicsState).
-  */
-  if (!allowCallbackEpicsState) {
-    return;
-  }
   const char* functionName = "adsDataCallback";
 
   if(!adsAsynPortObj){
@@ -186,10 +177,11 @@ static void adsDataCallback(const AmsAddr* pAddr, const AdsNotificationHeader* p
     return;
   }
 
-  paramInfo->plcTimeStampRaw=pNotification->nTimeStamp;
-  paramInfo->lastCallbackSize=pNotification->cbSampleSize;
-
-  adsAsynPortObj->adsUpdateParameterLock(paramInfo,data);
+  // Copy data into memory here so the ADS Recv queue can deallocate it
+  void* local_data = malloc(pNotification->cbSampleSize);
+  memcpy(local_data, data, pNotification->cbSampleSize);
+  adsAsynPortDriver::datacbinfo cbinfo = {paramInfo, local_data, *pNotification};
+  adsAsynPortObj->datacbqueue.push(cbinfo);
 }
 
 /** Start cyclic thread for supervision of connection.
@@ -211,6 +203,17 @@ void bulkReadThread(void *drvPvt)
   adsAsynPortDriver *pPvt = (adsAsynPortDriver *)drvPvt;
   pPvt->bulkReadThread();
 }
+
+/** Start data callback thread
+ * \param[in] drvPvt adsAsynPortDriver object
+ * \return void
+ */
+void dataCallbackThread(void *drvPvt)
+{
+  adsAsynPortDriver *pPvt = (adsAsynPortDriver *)drvPvt;
+  pPvt->dataCallbackThread();
+}
+
 
 /** Constructor for the adsAsynPortDriver class.
  * \param[in] portName Asyn port name.
@@ -376,6 +379,16 @@ adsAsynPortDriver::adsAsynPortDriver(const char *portName,
                                           epicsThreadPriorityMedium,
                                           epicsThreadGetStackSize(epicsThreadStackMedium),
                                           (EPICSTHREADFUNC)::bulkReadThread,this) == NULL);
+
+  if(status){
+    printf("%s:%s: epicsThreadCreate failure\n", driverName, functionName);
+    return;
+  }
+  //* Create the thread that does the ADS subscription callbacks */
+  status = (asynStatus)(epicsThreadCreate("adsAsynPortDriverDataCallbackThread",
+                                          epicsThreadPriorityMedium,
+                                          epicsThreadGetStackSize(epicsThreadStackMedium),
+                                          (EPICSTHREADFUNC)::dataCallbackThread,this) == NULL);
 
   if(status){
     printf("%s:%s: epicsThreadCreate failure\n", driverName, functionName);
@@ -553,12 +566,17 @@ void adsAsynPortDriver::bulkReadThread()
     long status;
     uint32_t cnt, readSize;
     asynUser *asynTraceUser=getTraceAsynUser();
-
-    gettimeofday(&now, NULL);
+    while (!bulkOK) {
+        usleep(1000000);
+    }
     while (1) {
-        start = now;
+        gettimeofday(&start, NULL);
         adsLock();
         for (int i = 0; bulk[i].cnt; i++) {
+            // Let other threads go, otherwise we can hold the lock for many timeouts
+            adsUnlock();
+            usleep(1);
+            adsLock();
             if (!bulkOK || !bulk[i].cnt) {
                 break;
             }
@@ -632,12 +650,29 @@ void adsAsynPortDriver::bulkReadThread()
 #ifdef MCB_DEBUG
         printf("ELAPSED: %g\n", bulk_elapsed_us / 1000000.0);
 #endif
-        if (bulk_elapsed_us < bulk_delay_us) {
-            usleep(bulk_delay_us - bulk_elapsed_us);
-            gettimeofday(&now, NULL);
-        }
+        // Always sleep at least 1 to let other threads acquire the ads lock
+        usleep(std::max(bulk_delay_us - bulk_elapsed_us, 1));
     }
 }
+
+
+/* Keeps possible slow data callbacks off of the ADS Recv queue*/
+void adsAsynPortDriver::dataCallbackThread()
+{
+    while (1) {
+        if (datacbqueue.empty() || !allowCallbackEpicsState) {
+            usleep(10000);
+            continue;
+        }
+        adsAsynPortDriver::datacbinfo* info = &datacbqueue.front();
+        info->paramInfo->plcTimeStampRaw = info->pNotification.nTimeStamp;
+        info->paramInfo->lastCallbackSize = info->pNotification.cbSampleSize;
+        adsUpdateParameterLock(info->paramInfo, info->data);
+        datacbqueue.pop();
+        free(info->data);
+    }
+}
+
 
 /** Report of configured parameters.
  * \param[in] fp Output file.

--- a/adsApp/src/adsAsynPortDriver.cpp
+++ b/adsApp/src/adsAsynPortDriver.cpp
@@ -2439,7 +2439,7 @@ asynStatus adsAsynPortDriver::writeInt32(asynUser *pasynUser, epicsInt32 value)
 
   // Warning. Risk of loss of data..
   if(sizeof(value)>maxBytesToWrite || sizeof(value)>paramInfo->plcSize){
-    asynPrint(pasynUser, ASYN_TRACE_WARNING, "%s:%s: WARNING. EPICS datatype size larger than PLC datatype size (%ld vs %d bytes).\n", driverName,functionName,sizeof(value),paramInfo->plcDataType);
+    asynPrint(pasynUser, ASYN_TRACE_WARNING, "%s:%s: WARNING. EPICS datatype size larger than PLC datatype size (%ld vs %d bytes).\n", driverName,functionName,sizeof(value),paramInfo->plcSize);
     paramInfo->plcDataTypeWarn=true;
   }
 

--- a/adsApp/src/adsAsynPortDriver.cpp
+++ b/adsApp/src/adsAsynPortDriver.cpp
@@ -677,9 +677,9 @@ void adsAsynPortDriver::dataCallbackThread()
         info->paramInfo->plcTimeStampRaw = info->pNotification.nTimeStamp;
         info->paramInfo->lastCallbackSize = info->pNotification.cbSampleSize;
         adsUpdateParameterLock(info->paramInfo, info->data);
-        datacbqueue.pop();
         // This free is for the malloc in adsDataCallback
         free(info->data);
+        datacbqueue.pop();
     }
 }
 

--- a/adsApp/src/adsAsynPortDriver.cpp
+++ b/adsApp/src/adsAsynPortDriver.cpp
@@ -140,8 +140,7 @@ static void adsDataCallback(const AmsAddr* pAddr, const AdsNotificationHeader* p
   }
 
   asynUser *asynTraceUser=adsAsynPortObj->getTraceAsynUser();
-  asynPrint(asynTraceUser, ASYN_TRACE_FLOW, "%s:%s:\n", driverName, functionName);
-  asynPrint(asynTraceUser, ASYN_TRACEIO_DRIVER , "%s:%s:\n", driverName, functionName);
+  asynPrint(asynTraceUser, ASYN_TRACE_FLOW | ASYN_TRACEIO_DRIVER, "%s:%s:\n", driverName, functionName);
 
   const uint8_t* data = reinterpret_cast<const uint8_t*>(pNotification + 1);
   struct timeval newTime;

--- a/adsApp/src/adsAsynPortDriver.h
+++ b/adsApp/src/adsAsynPortDriver.h
@@ -103,6 +103,7 @@ public:
   void dataCallbackThread();
   void poll_info(char *name);
   // data callback thread
+#define MAXCBQSIZE 10000
   struct datacbinfo {
     adsParamInfo*                paramInfo;
     void*                        data;

--- a/adsApp/src/adsAsynPortDriver.h
+++ b/adsApp/src/adsAsynPortDriver.h
@@ -10,6 +10,7 @@
 #include <vector>
 #include "adsAsynPortDriverUtils.h"
 #include <mutex>
+#include <queue>
 
 /** Class derived of asynPortDriver for ads communication with TwinCAT plc:s */
 
@@ -99,7 +100,15 @@ public:
 
   void cyclicThread();
   void bulkReadThread();
+  void dataCallbackThread();
   void poll_info(char *name);
+  // data callback thread
+  struct datacbinfo {
+    adsParamInfo*                paramInfo;
+    void*                        data;
+    const AdsNotificationHeader  pNotification;
+  };
+  std::queue<datacbinfo>         datacbqueue;
 protected:
 
 private:

--- a/configure/RELEASE.local
+++ b/configure/RELEASE.local
@@ -15,7 +15,7 @@
 # Define the version of modules needed by
 # IOC apps or other Support apps
 # ===============================================================
-ASYN_MODULE_VERSION = R4.39-1.0.2
+ASYN_MODULE_VERSION = R4.42-1.0.0
 #AXIS_MODULE_VERSION = R0.0.1
 
 # ==========================================================


### PR DESCRIPTION
## Jira Link
This is part of a collection of PRs aimed at solving https://jira.slac.stanford.edu/browse/ECS-8732


## Related PRs:

1. https://github.com/slac-epics/motor/pull/2
2. https://github.com/pcdshub/ethercatmc/pull/4
3. https://github.com/pcdshub/twincat-ads/pull/19
4. https://github.com/pcdshub/ioc-common-ads-ioc/pull/110

## Problem Statement
After updating the modules and running on rocky9, problems were reported with:

- PLCs with motors
- PLCs with cycle overruns

Where in certain cases (after moves, after errors, etc.) the iocsh output would be spammed with:
```
Sum read 0 failed: status 1861
Sum read 1 failed: status 1861
Sum read 2 failed: status 1861
Sum read 3 failed: status 1861
Sum read 4 failed: status 1861
Sum read 5 failed: status 1861
```
At which point, none of the PVs would be responsive and the IOC was effectively frozen and needed to be rebooted.


## Investigation 1
I was able to create a simple PLC program with the following features:

- Press a button to cause repeated cycle overruns
- Press a button to cause repeated motor errors (and clear them repeatedly)

<details>

```
PROGRAM Main
VAR
	{attribute 'pytmc' := 'pv: @(PREFIX)MMS:01'}
	M1: ST_MotionStage;
	fbM1: FB_MotionStage;
	
	fbCauseError: FB_CauseNCError;
	{attribute 'pytmc' := '
        pv: @(PREFIX)ERROR_CODE
		io: io
    '}
	nErrorCode: UDINT := 16#4550;
	{attribute 'pytmc' := '
        pv: @(PREFIX)ERROR_GO
		io: io
    '}
	nErrorExec: BOOL;
	bErrorClear: BOOL;
	
	{attribute 'pytmc' := '
        pv: @(PREFIX)DELAY_COUNT
		io: io
    '}
	nCycleDelaySetting: UDINT;
	nCycleDelayCount: UDINT;
	{attribute 'pytmc' := '
        pv: @(PREFIX)DELAY_GO
		io: io
    '}
	bCauseDelay: BOOL;
	bToggleError: BOOL;
END_VAR
```
```
// Normal motor setup
M1.bHardwareEnable := TRUE;
M1.bLimitForwardEnable := TRUE;
M1.bLimitBackwardEnable := TRUE;
M1.nEnableMode := E_StageEnableMode.ALWAYS;
fbM1(stMotionStage:=M1);

// Cause an NC error, one candidate for the IOC issues
fbCauseError(
	Axis:=M1.Axis,
	bExecute:=nErrorExec,
	nErrorCode:=nErrorCode,
);
IF fbCauseError.bDone THEN
	nErrorExec := FALSE;
END_IF
IF bErrorClear THEN
	bErrorClear := FALSE;
	M1.bReset := TRUE;
END_IF

// Cause a cycle overrun, one candidate for the IOC issues
IF bCauseDelay THEN
	nCycleDelayCount := nCycleDelaySetting;
	WHILE nCycleDelayCount > 0 DO
		nCycleDelayCount := nCycleDelayCount - 1;
	END_WHILE
END_IF

IF bToggleError THEN
	IF M1.bError THEN
		bErrorClear := TRUE;
	ELSE
		nErrorExec := TRUE;
	END_IF
END_IF
```

</details>

Using this program alongside a pytmc IOC, I was able to cause the sum read error spam consistently with either method.

I decided to crash the program during the sum read spam with `ctrl+\` to get a core dump. I evaluated that core dump using gdb and identified that we were in a deadlock. The "bulk read thread" was always in possession of the "ads lock" and trying to acquire the "asyn lock", the ads notify thread was always in possession of the "asyn lock" as part of a callback, and multiple threads were trying to acquire each of these locks.

To fix this, I changed the bulk read thread to always sleep for at least 1 microsecond between lock acquisition/removals. Somehow, it was reacquiring the lock faster than the scheduler could decide to switch to the other threads without this sleep.

After this fix, the IOC was crashing instead of freezing. Progress.


## Investigation 2

I changed the asyn trace mask to include flow and noticed that the troubles always started when specific PVs were processed at high rate (and, sometimes at low rate...). For the motor errors case, it was the symbols related to error handling, for the heavy load case it was the cycle overrun count. I checked all of these records and saw that they were using TS_MS, and also that they were the only records using TS_MS. I switched them to POLL_RATE and the issue went away. TS_MS is the indicator that a PV should be processed via notification callback instead of via bulk read.

This made me suspicious of the notification processing in this module. I looked into the internals and gained a fuller understanding about how these work. The problem is that the notification handling runs callbacks on the same thread as the one that processes incoming data from the PLC. If these callbacks take too much time, then other communication with the PLC is not processed in a timely manner and things break.

Why does this take longer now? Unclear.

To fix this, I made the data callbacks fill a queue with the notification data instead of directly processing the data on the ads recv queue. Then, I added a second thread that processes this data without blocking the network stack.

## Testing
The IOC no longer crashes and I am able to get very fast updates in EPICS

<details>

```
PLC:TST:ISSUES:MMS:01:PLC:bError_RBV 2025-10-10 10:11:15.634000 TRUE
PLC:TST:ISSUES:MMS:01:PLC:bError_RBV 2025-10-10 10:11:15.654000 FALSE
PLC:TST:ISSUES:MMS:01:PLC:bError_RBV 2025-10-10 10:11:15.674000 TRUE
PLC:TST:ISSUES:MMS:01:PLC:bError_RBV 2025-10-10 10:11:15.694000 FALSE
PLC:TST:ISSUES:MMS:01:PLC:bError_RBV 2025-10-10 10:11:15.714000 TRUE
PLC:TST:ISSUES:MMS:01:PLC:bError_RBV 2025-10-10 10:11:15.734000 FALSE
PLC:TST:ISSUES:MMS:01:PLC:bError_RBV 2025-10-10 10:11:15.754000 TRUE
PLC:TST:ISSUES:MMS:01:PLC:bError_RBV 2025-10-10 10:11:15.774000 FALSE
PLC:TST:ISSUES:MMS:01:PLC:bError_RBV 2025-10-10 10:11:15.794000 TRUE
PLC:TST:ISSUES:MMS:01:PLC:bError_RBV 2025-10-10 10:11:15.814000 FALSE
PLC:TST:ISSUES:MMS:01:PLC:bError_RBV 2025-10-10 10:11:15.834000 TRUE
PLC:TST:ISSUES:MMS:01:PLC:bError_RBV 2025-10-10 10:11:15.854000 FALSE
PLC:TST:ISSUES:MMS:01:PLC:bError_RBV 2025-10-10 10:11:15.874000 TRUE
PLC:TST:ISSUES:MMS:01:PLC:bError_RBV 2025-10-10 10:11:15.894000 FALSE
PLC:TST:ISSUES:MMS:01:PLC:bError_RBV 2025-10-10 10:11:15.914000 TRUE
PLC:TST:ISSUES:MMS:01:PLC:bError_RBV 2025-10-10 10:11:15.934000 FALSE
PLC:TST:ISSUES:MMS:01:PLC:bError_RBV 2025-10-10 10:11:15.954000 TRUE
PLC:TST:ISSUES:MMS:01:PLC:bError_RBV 2025-10-10 10:11:15.974000 FALSE
PLC:TST:ISSUES:MMS:01:PLC:bError_RBV 2025-10-10 10:11:15.994000 TRUE
PLC:TST:ISSUES:MMS:01:PLC:bError_RBV 2025-10-10 10:11:16.014000 FALSE
PLC:TST:ISSUES:MMS:01:PLC:bError_RBV 2025-10-10 10:11:16.034000 TRUE
PLC:TST:ISSUES:MMS:01:PLC:bError_RBV 2025-10-10 10:11:16.054000 FALSE
PLC:TST:ISSUES:MMS:01:PLC:bError_RBV 2025-10-10 10:11:16.074000 TRUE
PLC:TST:ISSUES:MMS:01:PLC:bError_RBV 2025-10-10 10:11:16.094000 FALSE
PLC:TST:ISSUES:MMS:01:PLC:bError_RBV 2025-10-10 10:11:16.114000 TRUE
PLC:TST:ISSUES:MMS:01:PLC:bError_RBV 2025-10-10 10:11:16.134000 FALSE
PLC:TST:ISSUES:MMS:01:PLC:bError_RBV 2025-10-10 10:11:16.154000 TRUE
PLC:TST:ISSUES:MMS:01:PLC:bError_RBV 2025-10-10 10:11:16.174000 FALSE
PLC:TST:ISSUES:MMS:01:PLC:bError_RBV 2025-10-10 10:11:16.194000 TRUE
PLC:TST:ISSUES:MMS:01:PLC:bError_RBV 2025-10-10 10:11:16.214000 FALSE
PLC:TST:ISSUES:MMS:01:PLC:bError_RBV 2025-10-10 10:11:16.234000 TRUE
PLC:TST:ISSUES:MMS:01:PLC:bError_RBV 2025-10-10 10:11:16.254000 FALSE
PLC:TST:ISSUES:MMS:01:PLC:bError_RBV 2025-10-10 10:11:16.274000 TRUE
```

</details>

The queue seems to get up to about size 15 during IOC startup and then bounces between 0 and 6 as I stress-test it with the error toggling.

It is worth doing further testing with a production PLC if/when one is available and safe to use.

## Changelog
(in the order of the diff)

- In `adsDataCallback`, remove the `allowCallbackEpicsState` check to move it to the data processing queue instead. It is OK to process these notifications at startup now because they no longer acquire locks.
- In `adsDataCallback`, add and adjust various `asynPrint`s
- In `adsDataCallback`, replace the `adsUpdateParameterLock` call with code that fills a queue with the relevant data instead.
- In the `adsAsynPortDriver` initialization, add a `dataCallbackThread`, following the examples from the other threads.
- In `bulkReadThread`, rearrange the `gettimeofday` handling to only use the minimum number of calls.
- In `bulkReadThread`, do not acquire any locks at all until `bulkOK`, otherwise we start acquiring this lock early and often without doing anything with it!
- In `bulkReadThread`, unlock, sleep, and relock on every distinct bulk read (the IOC splits these into 500 symbol chunks as per the Beckhoff docs) so that other threads can acquire the lock between bulk reads. This prevents issues with large numbers of bulk reads timing out in series and blocking other software from acquiring the lock. This is implemented with one unnecessary lock/unlock to make it more obvious that the locks would always be handled correctly.
- In `bulkReadThread`, instead of only sleeping if we handled the bulk reads quickly enough, always sleep at least 1 us per loop to give other threads another chance to acquire the lock.
- Add `dataCallbackThread` which processes items from the queue one at a time as they were previously done in `adsDataCallback`.
- In `writeInt32`, fix a malformed warning which was erroneously telling us that bools are 33 bytes large (reported by Yann)
- In the header file definition for `AdsAsynPortDriver`, add the `dataCallbackThread`, define a max queue size, and add a struct + queue combo that is used in the other functions.
- Update asyn to the version used in our other rocky9 IOCs