### PR TITLE
Add support for EPICS 7 data types (64-bit in/out ) scalars and array

### DIFF
--- a/adsApp/src/adsAsynPortDriver.cpp
+++ b/adsApp/src/adsAsynPortDriver.cpp
@@ -2702,7 +2702,11 @@ asynStatus adsAsynPortDriver::adsGenericArrayRead(asynUser *pasynUser,long allow
   adsParamInfo *paramInfo=pAdsParamArray_[paramIndex];
 
   //Only support same datatype as in PLC
-  if(paramInfo->plcDataType!=allowedType){
+  // Allow LWORD/ULINT as signed INT64
+  bool extendedAllowedType = (paramInfo->plcDataType == allowedType) ||
+    (paramInfo->plcDataType == ADST_UINT64 && allowedType == ADST_INT64);
+
+  if(!extendedAllowedType){
     asynPrint(pasynUser, ASYN_TRACE_ERROR, "%s:%s: Data types not compatible (%s vs %s). Read canceled.\n", driverName, functionName,adsTypeToString(paramInfo->plcDataType),adsTypeToString(allowedType));
     setAlarmParam(paramInfo,READ_ALARM,INVALID_ALARM);
     return asynError;
@@ -2758,7 +2762,11 @@ asynStatus adsAsynPortDriver::adsGenericArrayWrite(asynUser *pasynUser,long allo
   adsParamInfo *paramInfo=pAdsParamArray_[paramIndex];
 
   //Only support same datatype as in PLC
-  if(paramInfo->plcDataType!=allowedType){
+  // Allow LWORD/ULINT as signed INT64
+  bool extendedAllowedType = (paramInfo->plcDataType == allowedType) ||
+    (paramInfo->plcDataType == ADST_UINT64 && allowedType == ADST_INT64);
+
+  if(!extendedAllowedType){
     asynPrint(pasynUser, ASYN_TRACE_ERROR, "%s:%s: Data types not compatible (%s vs %s). Write canceled.\n", driverName, functionName,adsTypeToString(paramInfo->plcDataType),adsTypeToString(allowedType));
     setAlarmParam(paramInfo,WRITE_ALARM,INVALID_ALARM);
     return asynError;
@@ -4199,7 +4207,11 @@ asynStatus adsAsynPortDriver::adsUpdateParameter(adsParamInfo* paramInfo,const v
         case asynParamInt64:
           ret = setInteger64Param(paramInfo->paramIndex, (epicsInt64)(*ADST_UINT64Var));
           break;
-        // Arrays of unsigned not supported
+        // No 64 bit uint array callback type (also no 64bit uint in EPICS)
+        case asynParamInt64Array:
+          // handled in fireCallbacks()
+          ret=asynSuccess;
+          break;
         default:
           asynPrint(pasynUserSelf, ASYN_TRACE_ERROR, "%s:%s: Type combination not supported. PLC type = %s, ASYN type= %s\n", driverName, functionName,adsTypeToString(paramInfo->plcDataType),asynTypeToString(paramInfo->asynType));
           return asynError;
@@ -4378,6 +4390,18 @@ asynStatus adsAsynPortDriver::fireCallbacks(adsParamInfo* paramInfo)
       }
       break;
     case ADST_INT64:
+      switch(paramInfo->asynType){
+        case asynParamInt64Array:
+          ret= doCallbacksInt64Array((epicsInt64 *)paramInfo->arrayDataBuffer, paramInfo->lastCallbackSize / sizeof(epicsInt64), paramInfo->paramIndex, paramInfo->asynAddr);
+          break;
+        default:
+          asynPrint(pasynUserSelf, ASYN_TRACE_ERROR, "%s:%s: Type combination not supported. PLC type = %s, ASYN type= %s\n", driverName, functionName,adsTypeToString(paramInfo->plcDataType),asynTypeToString(paramInfo->asynType));
+          return asynError;
+          break;
+      }
+      break;
+	// No 64 bit uint array callback type -> cast into int64_t and use doCallbacksInt64Array
+    case ADST_UINT64:
       switch(paramInfo->asynType){
         case asynParamInt64Array:
           ret= doCallbacksInt64Array((epicsInt64 *)paramInfo->arrayDataBuffer, paramInfo->lastCallbackSize / sizeof(epicsInt64), paramInfo->paramIndex, paramInfo->asynAddr);

--- a/adsApp/src/adsAsynPortDriver.cpp
+++ b/adsApp/src/adsAsynPortDriver.cpp
@@ -1069,6 +1069,9 @@ asynStatus adsAsynPortDriver::drvUserCreate(asynUser *pasynUser,const char *drvI
     case asynParamFloat64:
       setDoubleParam(index,0);
       break;
+    case asynParamInt64:
+      setInteger64Param(index,0);
+      break;
     default:
       break;
   }

--- a/adsApp/src/adsAsynPortDriver.cpp
+++ b/adsApp/src/adsAsynPortDriver.cpp
@@ -4121,7 +4121,7 @@ asynStatus adsAsynPortDriver::adsUpdateParameter(adsParamInfo* paramInfo,const v
         case asynParamInt64:
           ret = setInteger64Param(paramInfo->paramIndex, *ADST_INT64Var);
           break;
-        // No 64 bit int array callback type (also no 64bit int in EPICS)
+        // No 64 bit uint array callback type (also no 64bit uint in EPICS)
         case asynParamInt64Array:
           // handled in fireCallbacks()
           ret=asynSuccess;
@@ -4518,6 +4518,9 @@ asynStatus adsAsynPortDriver::setAlarmParam(adsParamInfo *paramInfo,int alarm,in
         break;
       case asynParamInt32Array:
         stat=doCallbacksInt32Array((epicsInt32 *)paramInfo->arrayDataBuffer,writeSize/sizeof(epicsInt32), paramInfo->paramIndex,paramInfo->asynAddr);
+        break;
+      case asynParamInt64Array:
+        stat=doCallbacksInt64Array((epicsInt64 *)paramInfo->arrayDataBuffer,writeSize/sizeof(epicsInt64), paramInfo->paramIndex,paramInfo->asynAddr);
         break;
       case asynParamFloat32Array:
         stat=doCallbacksFloat32Array((epicsFloat32 *)paramInfo->arrayDataBuffer,writeSize/sizeof(epicsFloat32), paramInfo->paramIndex,paramInfo->asynAddr);

--- a/adsApp/src/adsAsynPortDriver.cpp
+++ b/adsApp/src/adsAsynPortDriver.cpp
@@ -256,8 +256,8 @@ adsAsynPortDriver::adsAsynPortDriver(const char *portName,
                                      ADSTIMESOURCE defaultTimeSource)
                      :asynPortDriver(portName,
                                      1, /* maxAddr */
-                                     asynInt32Mask | asynFloat64Mask | asynFloat32ArrayMask | asynFloat64ArrayMask | asynDrvUserMask | asynOctetMask | asynInt8ArrayMask | asynInt16ArrayMask | asynInt32ArrayMask, /* Interface mask */
-                                     asynInt32Mask | asynFloat64Mask | asynFloat32ArrayMask | asynFloat64ArrayMask | asynDrvUserMask | asynOctetMask | asynInt8ArrayMask | asynInt16ArrayMask | asynInt32ArrayMask,  /* Interrupt mask */
+									asynInt32Mask | asynFloat64Mask | asynInt64Mask | asynInt8ArrayMask | asynInt16ArrayMask | asynInt32ArrayMask | asynInt64ArrayMask | asynFloat32ArrayMask | asynFloat64ArrayMask | asynDrvUserMask | asynOctetMask, /* Interface mask */
+									asynInt32Mask | asynFloat64Mask | asynInt64Mask | asynInt8ArrayMask | asynInt16ArrayMask | asynInt32ArrayMask | asynInt64ArrayMask | asynFloat32ArrayMask | asynFloat64ArrayMask | asynDrvUserMask | asynOctetMask,  /* Interrupt mask */
                                      ASYN_CANBLOCK, /* asynFlags.  This driver does not block and it is not multi-device, so flag is 0 */
                                      autoConnect, /* Autoconnect */
                                      priority, /* Default priority */
@@ -2384,12 +2384,6 @@ asynStatus adsAsynPortDriver::writeInt32(asynUser *pasynUser, epicsInt32 value)
       *ADST_INT32Var=(int32_t)value;
       maxBytesToWrite=4;
       break;
-    case ADST_INT64:
-      int64_t *ADST_INT64Var;
-      ADST_INT64Var=((int64_t*)buffer);
-      *ADST_INT64Var=(int64_t)value;
-      maxBytesToWrite=8;
-      break;
     case ADST_UINT8:
       uint8_t *ADST_UINT8Var;
       ADST_UINT8Var=((uint8_t*)buffer);
@@ -2407,12 +2401,6 @@ asynStatus adsAsynPortDriver::writeInt32(asynUser *pasynUser, epicsInt32 value)
       ADST_UINT32Var=((uint32_t*)buffer);
       *ADST_UINT32Var=(uint32_t)value;
       maxBytesToWrite=4;
-      break;
-    case ADST_UINT64:
-      uint64_t *ADST_UINT64Var;
-      ADST_UINT64Var=((uint64_t*)buffer);
-      *ADST_UINT64Var=(uint64_t)value;
-      maxBytesToWrite=8;
       break;
     case ADST_REAL32:
       float *ADST_REAL32Var;
@@ -2463,6 +2451,86 @@ asynStatus adsAsynPortDriver::writeInt32(asynUser *pasynUser, epicsInt32 value)
 
   return asynPortDriver::writeInt32(pasynUser, value);
 }
+
+asynStatus adsAsynPortDriver::writeInt64(asynUser *pasynUser, epicsInt64 value)
+{
+    const char* functionName = "writeInt64";
+    asynPrint(pasynUser, ASYN_TRACE_FLOW, "%s:%s:\n", driverName, functionName);
+    adsParamInfo *paramInfo;
+    int paramIndex = pasynUser->reason;
+
+    if (!pAdsParamArray_[paramIndex]) {
+        asynPrint(pasynUser, ASYN_TRACE_ERROR, "%s:%s: pAdsParamArray NULL\n", driverName, functionName);
+        pasynUser->alarmStatus = WRITE_ALARM;
+        callParamCallbacks();
+        return asynError;
+    }
+
+    paramInfo = pAdsParamArray_[paramIndex];
+
+    // Special case: AMS port state
+    if (paramInfo->dataSource == ADS_DATASOURCE_AMS_STATE) {
+        if (adsWriteState(paramInfo->amsPort, (uint16_t)value) != asynSuccess) {
+            return setAlarmParam(paramInfo, WRITE_ALARM, INVALID_ALARM);
+        }
+        if (paramInfo->alarmStatus == WRITE_ALARM) {
+            return setAlarmParam(paramInfo, NO_ALARM, NO_ALARM);
+        }
+        return asynSuccess;
+    }
+
+    uint8_t buffer[8]; // 8 bytes for int64_t/uint64_t/double
+    uint32_t maxBytesToWrite = 0;
+
+    switch(paramInfo->plcDataType){
+        case ADST_INT64:
+        {
+            int64_t *ADST_INT64Var = (int64_t*)buffer;
+            *ADST_INT64Var = (int64_t)value;
+            maxBytesToWrite = 8;
+            break;
+        }
+        case ADST_UINT64:
+        {
+            uint64_t *ADST_UINT64Var = (uint64_t*)buffer;
+            *ADST_UINT64Var = (uint64_t)value; // User beware: signed->unsigned cast!
+            maxBytesToWrite = 8;
+            break;
+        }
+        default:
+            asynPrint(pasynUser, ASYN_TRACE_ERROR, "%s:%s: Data types not compatible (epicsInt64 and %s). Write canceled.\n", driverName, functionName, adsTypeToString(paramInfo->plcDataType));
+            return asynError;
+    }
+
+    // Sanity: Check PLC buffer sizes
+    if (sizeof(value) > maxBytesToWrite || sizeof(value) > paramInfo->plcSize) {
+        asynPrint(pasynUser, ASYN_TRACE_WARNING, "%s:%s: WARNING. EPICS datatype size larger than PLC datatype size (%ld vs %d bytes).\n",
+            driverName, functionName, sizeof(value), paramInfo->plcSize);
+        paramInfo->plcDataTypeWarn = true;
+    }
+
+    // Ensure match
+    if (maxBytesToWrite != paramInfo->plcSize || maxBytesToWrite == 0) {
+        asynPrint(pasynUser, ASYN_TRACE_ERROR, "%s:%s: Data types size mismatch (%s and %d bytes). Write canceled.\n",
+            driverName, functionName, adsTypeToString(paramInfo->plcDataType), maxBytesToWrite);
+        setAlarmParam(paramInfo, WRITE_ALARM, INVALID_ALARM);
+        callParamCallbacks();
+        return asynError;
+    }
+
+    // Write the value
+    if (adsWriteParam(paramInfo, buffer, maxBytesToWrite) != asynSuccess) {
+        setAlarmParam(paramInfo, WRITE_ALARM, INVALID_ALARM);
+        callParamCallbacks();
+        return asynError;
+    }
+    if (paramInfo->alarmStatus == WRITE_ALARM) {
+        setAlarmParam(paramInfo, NO_ALARM, NO_ALARM);
+    }
+
+    return asynPortDriver::writeInt64(pasynUser, value);
+}
+
 
 /** Overrides asynPortDriver::writeFloat64.
  * Writes float64 to PLC
@@ -2852,6 +2920,7 @@ asynStatus adsAsynPortDriver::readInt32Array(asynUser *pasynUser,epicsInt32 *val
   return asynSuccess;
 }
 
+
 /** Overrides asynPortDriver::writeInt32Array.
  * Writes int32Array
  * \param[in] pasynUser Pointer to asyn user structure
@@ -2910,6 +2979,33 @@ asynStatus adsAsynPortDriver::writeFloat32Array(asynUser *pasynUser,epicsFloat32
 
   long allowedType=ADST_REAL32;
   return adsGenericArrayWrite(pasynUser,allowedType,(const void *)value,nElements*sizeof(epicsFloat32));
+}
+
+
+asynStatus adsAsynPortDriver::readInt64Array(asynUser *pasynUser, epicsInt64 *value, size_t nElements, size_t *nIn)
+{
+    const char* functionName = "readInt64Array";
+    asynPrint(pasynUser, ASYN_TRACE_FLOW, "%s:%s:\n", driverName, functionName);
+
+    long allowedType = ADST_INT64;
+
+    size_t nBytesRead = 0;
+    asynStatus stat = adsGenericArrayRead(pasynUser, allowedType, (void *)value, nElements * sizeof(epicsInt64), &nBytesRead);
+    if (stat != asynSuccess) {
+        return asynError;
+    }
+    *nIn = nBytesRead / sizeof(epicsInt64);
+    return asynSuccess;
+}
+
+asynStatus adsAsynPortDriver::writeInt64Array(asynUser *pasynUser, epicsInt64 *value, size_t nElements)
+{
+    const char* functionName = "writeInt64Array";
+    asynPrint(pasynUser, ASYN_TRACE_FLOW, "%s:%s:\n", driverName, functionName);
+
+    long allowedType = ADST_INT64;
+
+    return adsGenericArrayWrite(pasynUser, allowedType, (const void *)value, nElements * sizeof(epicsInt64));
 }
 
 /** Overrides asynPortDriver::readFloat64Array.
@@ -4019,7 +4115,14 @@ asynStatus adsAsynPortDriver::adsUpdateParameter(adsParamInfo* paramInfo,const v
         case asynParamFloat64:
           ret=setDoubleParam(paramInfo->paramIndex,(double)(*ADST_INT64Var));
           break;
+        case asynParamInt64:
+          ret = setInteger64Param(paramInfo->paramIndex, *ADST_INT64Var);
+          break;
         // No 64 bit int array callback type (also no 64bit int in EPICS)
+        case asynParamInt64Array:
+          // handled in fireCallbacks()
+          ret=asynSuccess;
+          break;
         default:
           asynPrint(pasynUserSelf, ASYN_TRACE_ERROR, "%s:%s: Type combination not supported. PLC type = %s, ASYN type= %s\n", driverName, functionName,adsTypeToString(paramInfo->plcDataType),asynTypeToString(paramInfo->asynType));
           return asynError;
@@ -4089,6 +4192,9 @@ asynStatus adsAsynPortDriver::adsUpdateParameter(adsParamInfo* paramInfo,const v
           break;
         case asynParamFloat64:
           ret=setDoubleParam(paramInfo->paramIndex,(double)(*ADST_UINT64Var));
+          break;
+        case asynParamInt64:
+          ret = setInteger64Param(paramInfo->paramIndex, (epicsInt64)(*ADST_UINT64Var));
           break;
         // Arrays of unsigned not supported
         default:
@@ -4268,7 +4374,17 @@ asynStatus adsAsynPortDriver::fireCallbacks(adsParamInfo* paramInfo)
           break;
       }
       break;
-
+    case ADST_INT64:
+      switch(paramInfo->asynType){
+        case asynParamInt64Array:
+          ret= doCallbacksInt64Array((epicsInt64 *)paramInfo->arrayDataBuffer, paramInfo->lastCallbackSize / sizeof(epicsInt64), paramInfo->paramIndex, paramInfo->asynAddr);
+          break;
+        default:
+          asynPrint(pasynUserSelf, ASYN_TRACE_ERROR, "%s:%s: Type combination not supported. PLC type = %s, ASYN type= %s\n", driverName, functionName,adsTypeToString(paramInfo->plcDataType),asynTypeToString(paramInfo->asynType));
+          return asynError;
+          break;
+      }
+      break;
     case ADST_REAL32:
       switch(paramInfo->asynType){
         case asynParamFloat32Array:

--- a/adsApp/src/adsAsynPortDriver.h
+++ b/adsApp/src/adsAsynPortDriver.h
@@ -84,6 +84,17 @@ public:
   virtual asynStatus writeFloat64Array(asynUser *pasynUser,
                                        epicsFloat64 *value,
                                        size_t nElements);
+  // 64-bit integer interface support (asynInt64 and asynInt64Array)
+  virtual asynStatus writeInt64(asynUser *pasynUser,
+                                        epicsInt64 value);
+  virtual asynStatus readInt64Array(asynUser *pasynUser,
+                                        epicsInt64 *value,
+                                        size_t nElements,
+                                        size_t *nIn);
+  virtual asynStatus writeInt64Array(asynUser *pasynUser,
+                                        epicsInt64 *value,
+                                        size_t nElements);
+
   asynStatus adsUpdateParameterLock(adsParamInfo* paramInfo,
                                     const void *data);
   asynStatus invalidateParamsLock(uint16_t amsPort);

--- a/adsApp/src/adsAsynPortDriverUtils.cpp
+++ b/adsApp/src/adsAsynPortDriverUtils.cpp
@@ -274,6 +274,10 @@ const char *asynTypeToString(long type)
       return "asynParamFloat64Array";
     case asynParamGenericPointer:
       return "asynParamGenericPointer";
+    case asynParamInt64:
+      return "asynParamInt64";
+    case asynParamInt64Array:
+      return "asynParamInt64Array";
     default:
       return "asynUnknownType";
   }
@@ -432,6 +436,12 @@ asynParamType dtypStringToAsynType(char *dtype)
   }
   if(strcmp("asynFloat64ArrayIn",dtype)==0 || strcmp("asynFloat64ArrayOut",dtype)==0){
     return asynParamFloat64Array;
+  }
+  if(strcmp("asynInt64",dtype)==0){
+    return asynParamInt64;
+  }
+  if(strcmp("asynInt64ArrayIn",dtype)==0 || strcmp("asynInt64ArrayOut",dtype)==0){
+    return asynParamInt64Array;
   }
   //  asynParamUInt32Digital,
   //  asynParamOctet,
@@ -824,7 +834,7 @@ int octetBinary2ascii(bool returnVarName,
         RETURN_VAR_NAME_IF_NEEDED;
         int64_t *ADST_INT64Var;
         ADST_INT64Var=((int64_t*)binaryBuffer)+cycles;
-        octetCmdBuf_printf(asciiBuffer,"% PRId64",*ADST_INT64Var);
+        octetCmdBuf_printf(asciiBuffer,"%" PRId64,*ADST_INT64Var);
         //printf("Binary 2 ASCII ADST_INT64, value: %" PRId64 "\n", *ADST_INT64Var);
         bytesPerDataPoint=8;
         bytesProcessed+=bytesPerDataPoint;
@@ -860,7 +870,7 @@ int octetBinary2ascii(bool returnVarName,
         RETURN_VAR_NAME_IF_NEEDED;
         uint64_t *ADST_UINT64Var;
         ADST_UINT64Var=((uint64_t*)binaryBuffer)+cycles;
-        octetCmdBuf_printf(asciiBuffer,"% PRIu64",*ADST_UINT64Var);
+        octetCmdBuf_printf(asciiBuffer,"%" PRIu64,*ADST_UINT64Var);
         //printf("Binary 2 ASCII ADST_UINT64, value: %" PRIu64 "\n", *ADST_UINT64Var);
         bytesPerDataPoint=8;
         bytesProcessed+=bytesPerDataPoint;

--- a/adsApp/src/adsAsynPortDriverUtils.cpp
+++ b/adsApp/src/adsAsynPortDriverUtils.cpp
@@ -870,7 +870,7 @@ int octetBinary2ascii(bool returnVarName,
         RETURN_VAR_NAME_IF_NEEDED;
         uint64_t *ADST_UINT64Var;
         ADST_UINT64Var=((uint64_t*)binaryBuffer)+cycles;
-        octetCmdBuf_printf(asciiBuffer,"%" PRIu64,*ADST_UINT64Var);
+        octetCmdBuf_printf(asciiBuffer,"% PRIu64",*ADST_UINT64Var);
         //printf("Binary 2 ASCII ADST_UINT64, value: %" PRIu64 "\n", *ADST_UINT64Var);
         bytesPerDataPoint=8;
         bytesProcessed+=bytesPerDataPoint;

--- a/adsApp/src/adsAsynPortDriverUtils.cpp
+++ b/adsApp/src/adsAsynPortDriverUtils.cpp
@@ -834,7 +834,7 @@ int octetBinary2ascii(bool returnVarName,
         RETURN_VAR_NAME_IF_NEEDED;
         int64_t *ADST_INT64Var;
         ADST_INT64Var=((int64_t*)binaryBuffer)+cycles;
-        octetCmdBuf_printf(asciiBuffer,"%" PRId64,*ADST_INT64Var);
+        octetCmdBuf_printf(asciiBuffer,"% PRId64",*ADST_INT64Var);
         //printf("Binary 2 ASCII ADST_INT64, value: %" PRId64 "\n", *ADST_INT64Var);
         bytesPerDataPoint=8;
         bytesProcessed+=bytesPerDataPoint;


### PR DESCRIPTION
- Add support for EPICS 7 data types (64-bit in/out ), scalars and arrays
- Asyn does not provide UINT64 interface, thus ULINT and LWORD are type casted into epicsInt64(in line with similar and existing handling)
Context: https://jira.slac.stanford.edu/browse/ECS-9425
              https://jira.slac.stanford.edu/browse/ECS-8684
Testing procedure:

- Typical PLC Motion program (with 64-bit pytmc pragma'd variables)running on plc-tst-bsd2
- Typical IOC running on ctl-tst-dev-02

Test consisted:
- Monitoring update from the PLC for  each scalar(LINT, ULINT, LWORD)
- Update each scalar (LINT, ULINT, LWORD) on EPICS and monitoring update on PLC
- Monitoring update from the PLC for each array of types r(LINT, ULINT, LWORD)
- Update each array (LINT, ULINT, LWORD) on EPICS and monitoring update on PLC
-
See 1-tot-1 logs of these processes here:https://jira.slac.stanford.edu/browse/ECS-9425
Below is the issue that was noted coming from autosave handling of 64-bit types (most probably arrays) when writing from the IOC
<img width="3482" height="1680" alt="64-bits-autosave-issue" src="https://github.com/user-attachments/assets/0419526a-aa49-4d97-9239-8669cce7afab" />
