### PR TITLE
Bugfix desync

### DIFF
--- a/adsApp/src/adsAsynPortDriver.cpp
+++ b/adsApp/src/adsAsynPortDriver.cpp
@@ -1409,7 +1409,7 @@ asynStatus adsAsynPortDriver::disconnectLock(asynUser *pasynUser)
 asynStatus adsAsynPortDriver::disconnect(asynUser *pasynUser)
 {
   const char* functionName = "disconnect";
-  asynPrint(pasynUser, ASYN_TRACE_ERROR, "%s:%s:\n", driverName, functionName);
+  asynPrint(pasynUser, ASYN_TRACE_FLOW, "%s:%s:\n", driverName, functionName);
 
   if(asynPortDriver::disconnect(pasynUser)!=asynSuccess){
     return asynError;

--- a/adsApp/src/adsAsynPortDriver.cpp
+++ b/adsApp/src/adsAsynPortDriver.cpp
@@ -7,9 +7,13 @@
 *
 * Author: Anders Sandström
 * Edited to add bulk reads: Michael Browne
+* Edited to add bulk symbol resolution: Yann Stephen Mandza
+* Edited to resolve de-sync I/O Intr issues: Nicholas Lentz
 *
 * Created January 25, 2018
 * Edited  December 6, 2019
+* Edited  March 10, 2026
+* Edited  March 11, 2026
 */
 #define USE_TYPED_RSET    // Shut up about rset already!
 #include "adsAsynPortDriver.h"
@@ -202,12 +206,11 @@ static void getEpicsState(initHookState state)
     case initHookAfterScanInit:
       allowCallbackEpicsState=1;
 
-      //make all callbacks if data arrived from callback before interrupts were registered (before allowCallbackEpicsState==1)
       if(!adsAsynPortObj){
         printf("%s:%s: ERROR: adsAsynPortObj==NULL\n", driverName, functionName);
         return;
       }
-      adsAsynPortObj->fireAllCallbacksLock();
+      
       adsAsynPortObj->bulkOK = 1;
       printf("Begin polling PLC!\n");
       break;
@@ -249,11 +252,20 @@ static void adsSymbolsChangedCallback(const AmsAddr* pAddr, const AdsNotificatio
     return;
   }
 
+  long amsClientPort = 0;
+  AdsClientPortGuard adsClientPortGuard(*adsAsynPortObj, amsClientPort);
+  if (isInvalidPortNumber(amsClientPort))
+  {
+    throw std::runtime_error(string_format(
+        "%s:%s: failed to open ads client port for this thread.\n", 
+        driverName, __func__));
+  }
+
   asynUser *asynTraceUser=adsAsynPortObj->getTraceAsynUser();
   asynPrint(asynTraceUser, ASYN_TRACE_INFO , "%s:%s: Symbols changed for Ams-port %u.\n", driverName, functionName,pAddr->port);
 
   adsAsynPortObj->invalidateParamsLock(pAddr->port);
-  adsAsynPortObj->refreshParamsLock(pAddr->port);
+  adsAsynPortObj->refreshParamsLock(amsClientPort, pAddr->port);
 }
 
 /** Callback from ads lib for updated data.
@@ -352,6 +364,16 @@ void dataCallbackThread(void *drvPvt)
   pPvt->dataCallbackThread();
 }
 
+/** Start trigger IO Intr Callbacks thread
+ * \param[in] drvPvt adsAsynPortDriver object
+ * \return void
+ */
+void triggerEpicsIoIntrCallbacksThread(void *drvPvt)
+{
+  adsAsynPortDriver *pPvt = (adsAsynPortDriver *)drvPvt;
+  pPvt->triggerEpicsIoIntrCallbacksThread();
+}
+
 /*
  * SUMUP handle resolution
  *
@@ -365,7 +387,7 @@ void dataCallbackThread(void *drvPvt)
  *            followed by N × name strings (no null terminator needed)
  *   Read   : N × (result_code uint32 + handle uint32)  = N×8 bytes
  * */
-asynStatus adsAsynPortDriver::resolveSymbolHandles()
+asynStatus adsAsynPortDriver::resolveSymbolHandles(uint16_t amsClientPort)
 {
     static const char *functionName = "resolveSymbolHandles";
     if (symbolDict_.empty()) return asynSuccess;
@@ -426,12 +448,13 @@ asynStatus adsAsynPortDriver::resolveSymbolHandles()
         /* ADS SUMUP READWRITE call */
         AmsAddr remote;
         remote.netId = remoteNetId_;
-        remote.port  = amsportDefault_;
+        remote.port  = amsportDefault_; // Needs to chunk based on amsServer port but it isn't. 
+        // ^ This assumes everything is ams server port 851 which is probably almost everything but not quite.
+
         uint32_t bytesRead = 0;
 
-        adsLock();
         long rc = AdsSyncReadWriteReqEx2(
-            adsPort_,
+            amsClientPort,
             &remote,
             ADSIGRP_SUMUP_READWRITE,   /* 0xF082 */
             (uint32_t)chunkN,          /* iOffset = number of sub-requests */
@@ -440,7 +463,6 @@ asynStatus adsAsynPortDriver::resolveSymbolHandles()
             (uint32_t)writeBytes,
             writeBuf.data(),
             &bytesRead);
-        adsUnlock();
 
         asynPrint(pasynUserSelf, ASYN_TRACE_FLOW,
                   "%s::%s: chunk %zu/%zu rc=0x%lx "
@@ -513,7 +535,7 @@ asynStatus adsAsynPortDriver::resolveSymbolHandles()
  *
  * Called once from drvUserCreate() after all DB records are loaded.
  * */
-asynStatus adsAsynPortDriver::resolveSymbolInfo()
+asynStatus adsAsynPortDriver::resolveSymbolInfo(uint16_t amsClientPort)
 {
     static const char *functionName = "resolveSymbolInfo";
 
@@ -591,7 +613,8 @@ asynStatus adsAsynPortDriver::resolveSymbolInfo()
 
     AmsAddr remote;
     remote.netId = remoteNetId_;
-    remote.port  = amsportDefault_;
+    remote.port  = amsportDefault_; // Needs to chunk based on amsServer port but it isn't. 
+    // ^ This assumes everything is ams server port 851 which is probably almost everything but not quite.
 
     for (size_t chunk = 0; chunk < nChunks; ++chunk) {
 
@@ -630,15 +653,14 @@ asynStatus adsAsynPortDriver::resolveSymbolInfo()
 
         /* ADS call */
         uint32_t bytesRead = 0;
-        adsLock();
+        
         long rc = AdsSyncReadWriteReqEx2(
-            adsPort_, &remote,
+            amsClientPort, &remote,
             ADSIGRP_SUMUP_READWRITE,
             (uint32_t)chunkN,
             (uint32_t)readBytes,  readBuf.data(),
             (uint32_t)writeBytes, writeBuf.data(),
             &bytesRead);
-        adsUnlock();
 
         if (rc != 0) {
             asynPrint(pasynUserSelf, ASYN_TRACE_ERROR,
@@ -779,8 +801,7 @@ adsAsynPortDriver::adsAsynPortDriver(const char *portName,
   //Extra Debugging from the beginning: pasynTrace->setTraceMask(pasynUserSelf, 0x11);
   asynPrint(pasynUserSelf,ASYN_TRACE_FLOW, "%s:%s:\n", driverName, functionName);
 
-  pAdsParamArray_= new adsParamInfo*[paramTableSize];
-  memset(pAdsParamArray_,0,sizeof(*pAdsParamArray_));
+  adsParamArray_.resize(paramTableSize);
   adsParamArrayCount_=0;
   paramTableSize_=paramTableSize;
   ipaddr_=strdup(ipaddr);
@@ -796,7 +817,6 @@ adsAsynPortDriver::adsAsynPortDriver(const char *portName,
   routeAdded_=0;
   notConnectedCounter_ = 0;
   oneAmsConnectionOKold_=0;
-  adsUnlock();
 
   //Octet interface
   octetAsciiBuffer_.bufferSize = ADS_CMD_BUFFER_SIZE;
@@ -844,24 +864,47 @@ adsAsynPortDriver::adsAsynPortDriver(const char *portName,
     asynPrint(pasynUserSelf, ASYN_TRACE_ERROR, "%s:%s: createParam for default access failed.\n", driverName, functionName);
     return;
   }
-  adsParamInfo *paramInfo=new adsParamInfo();
-  memset(paramInfo,0,sizeof(adsParamInfo));
-  paramInfo->recordName=strdup("Any record");
-  paramInfo->recordType=strdup("No type");
-  paramInfo->scan=strdup("No scan");
-  paramInfo->dtyp=strdup("No dtyp");
-  paramInfo->inp=strdup("No inp");
-  paramInfo->out=strdup("No out");
-  paramInfo->drvInfo=strdup("No drvinfo");
-  paramInfo->asynType=asynParamNotDefined;
-  paramInfo->paramIndex=index;  //also used as hUser for ads callback
-  paramInfo->plcAdrStr=strdup("No adr str");
-  pAdsParamArray_[0]=paramInfo;
+  adsParamArray_[0].recordName=strdup("Any record");
+  adsParamArray_[0].recordType=strdup("No type");
+  adsParamArray_[0].scan=strdup("No scan");
+  adsParamArray_[0].dtyp=strdup("No dtyp");
+  adsParamArray_[0].inp=strdup("No inp");
+  adsParamArray_[0].out=strdup("No out");
+  adsParamArray_[0].drvInfo=strdup("No drvinfo");
+  adsParamArray_[0].asynType=asynParamNotDefined;
+  adsParamArray_[0].paramIndex=index;  //also used as hUser for ads callback
+  adsParamArray_[0].plcAdrStr=strdup("No adr str");
   adsParamArrayCount_++;
 
   if(status!=asynSuccess){
     asynPrint(pasynUserSelf, ASYN_TRACE_ERROR, "%s:%s: createParam for default access failed.\n", driverName, functionName);
     return;
+  }
+
+  // Open a client side ads port.
+  // This doesn't require any communication with the server side, it is just to establish a unique
+  // identifier for the ads communication calls coming from this thread.
+  // All this really does is find the lowest available port number not currently open for the ads router on this client.
+  // It would only fail if we have run out of available port numbers, which is any number between
+  // 1 and UINT16_MAX = 65535 inclusive.
+  // Each thread will get its own port number, and we will just make sure to close them when we don't
+  // need them anymore. Most likely this class's destructor or earlier if we want.
+  // Open a default client port.
+  adsPort_ = addAdsClientPortNumberForThreadId(0);
+  if (isInvalidPortNumber(adsPort_))
+  {
+    throw std::runtime_error(string_format(
+        "%s:%s: failed to open default ads client port: %d.\n", driverName, __func__));
+  }
+
+  // Create an ads client port that will automatically be closed when this function leaves scope.
+  long amsClientPort = 0;
+  AdsClientPortGuard adsClientPortGuard(*this, amsClientPort);
+  if (isInvalidPortNumber(amsClientPort))
+  {
+    amsClientPort = getAdsClientPortNumberForThreadId(0);
+    asynPrint(pasynUserSelf, ASYN_TRACE_ERROR,
+              "%s:%s: failed to get ads client port. Fallback to default client port.\n", driverName, __func__);
   }
 
   //* Create the thread that computes the waveforms in the background */
@@ -911,9 +954,21 @@ adsAsynPortDriver::adsAsynPortDriver(const char *portName,
     printf("%s:%s: epicsThreadCreate failure\n", driverName, functionName);
     return;
   }
+
+  //* Create the thread that does I/O Intr callback triggers */
+  status = (asynStatus)(epicsThreadCreate("adsAsynPortDriverTriggerEpicsIoIntrCallbacksThread",
+                                          epicsThreadPriorityHigh,
+                                          epicsThreadGetStackSize(epicsThreadStackMedium),
+                                          (EPICSTHREADFUNC)::triggerEpicsIoIntrCallbacksThread, this) == NULL);
+  if (status)
+  {
+    throw std::runtime_error(string_format(
+      "%s:%s: epicsThreadCreate failure for TriggerEpicsIoIntrCallbacksThread.\n",
+       driverName, __func__));
+  }
  
   //try to connect, and hang until we succeed!
-  for (;;) {
+  while (true) {
       if (connect(pasynUserSelf) != asynSuccess) {
       asynPrint(pasynUserSelf, ASYN_TRACE_ERROR, 
             "%s:%s: connect failed for port %s.\n", 
@@ -923,7 +978,7 @@ adsAsynPortDriver::adsAsynPortDriver(const char *portName,
       }
       long error = 0;
       uint16_t adsState = 0;
-      if (adsReadStateLock(amsport,&adsState,true,&error) != asynSuccess) {
+      if (adsReadState(amsClientPort,amsport,&adsState,true,&error) != asynSuccess) {
       asynPrint(pasynUserSelf, ASYN_TRACE_ERROR, 
             "%s:%s: adsReadStateLock failed for port %s.\n", 
             driverName, functionName, portName);
@@ -954,30 +1009,27 @@ adsAsynPortDriver::~adsAsynPortDriver()
   free(ipaddr_);
   free(amsaddr_);
 
+  // Only default ams client port remains so we use that to delete the ads callbacks and release symbolic handles.
   for(int i=0;i<adsParamArrayCount_;i++){
-    if(!pAdsParamArray_[i]){
-      continue;
-    }
-    adsDelDataCallback(pAdsParamArray_[i],true);  //Block error messages
-    adsReleaseSymbolicHandle(pAdsParamArray_[i],true);    //Block error messages
-    free(pAdsParamArray_[i]->recordName);
-    free(pAdsParamArray_[i]->recordType);
-    free(pAdsParamArray_[i]->scan);
-    free(pAdsParamArray_[i]->dtyp);
-    free(pAdsParamArray_[i]->inp);
-    free(pAdsParamArray_[i]->out);
-    free(pAdsParamArray_[i]->drvInfo);
-    free(pAdsParamArray_[i]->plcAdrStr);
-    if(pAdsParamArray_[i]->plcDataIsArray){
-      free(pAdsParamArray_[i]->arrayDataBuffer);
-    }
-    delete pAdsParamArray_[i];
+    adsDelDataCallback(adsPort_, &adsParamArray_[i],true);  //Block error messages
+    adsReleaseSymbolicHandle(adsPort_, &adsParamArray_[i],true);    //Block error messages
+    free(adsParamArray_[i].recordName);
+    free(adsParamArray_[i].recordType);
+    free(adsParamArray_[i].scan);
+    free(adsParamArray_[i].dtyp);
+    free(adsParamArray_[i].inp);
+    free(adsParamArray_[i].out);
+    free(adsParamArray_[i].drvInfo);
+    free(adsParamArray_[i].plcAdrStr);
+    if(adsParamArray_[i].plcDataIsArray){
+      free(adsParamArray_[i].arrayDataBuffer);
   }
-  delete pAdsParamArray_;
+  }
 
   for(amsPortInfo *port : amsPortList_){
     delete port;
   }
+  AdsPortCloseEx(adsPort_);
 }
 
 /** Cyclic thread for supervision of connection.
@@ -987,6 +1039,15 @@ adsAsynPortDriver::~adsAsynPortDriver()
  */
 void adsAsynPortDriver::cyclicThread()
 {
+  long amsClientPort = 0;
+  AdsClientPortGuard adsClientPortGuard(*this, amsClientPort);
+  if (isInvalidPortNumber(amsClientPort))
+  {
+    throw std::runtime_error(string_format(
+        "%s:%s: failed to open ads client port for this thread.\n", 
+        driverName, __func__));
+  }
+
   const char* functionName = "cyclicThread";
   double sampleTime=0.5;
   while (1){
@@ -1000,10 +1061,9 @@ void adsAsynPortDriver::cyclicThread()
     uint16_t adsState=0;
     //Check state of all used ams ports
     bool oneAmsConnectionOK=false;
-    if(connectedAds_){
       for(amsPortInfo *port : amsPortList_){
         long error=0;
-        asynStatus stat=adsReadStateLock(port->amsPort,&adsState,true,&error);
+        asynStatus stat=adsReadState(amsClientPort,port->amsPort,&adsState,true,&error);
         bool portConnected=(stat==asynSuccess && adsState == ADSSTATE_RUN);
         port->adsStateOld=port->adsState;
         if(stat==asynSuccess){
@@ -1020,22 +1080,20 @@ void adsAsynPortDriver::cyclicThread()
         oneAmsConnectionOK=oneAmsConnectionOK || portConnected;
 
         if(port->connected && port->refreshNeeded){
-          refreshParamsLock(port->amsPort);
+          refreshParamsLock(amsClientPort,port->amsPort);
         }
         if(port->connectedOld && !port->connected){
           invalidateParamsLock(port->amsPort);
           port->refreshNeeded=true;
           setAlarmPortLock(port->amsPort,COMM_ALARM,INVALID_ALARM);
           asynPrint(pasynUserSelf, ASYN_TRACE_ERROR, 
-            "%s:%s: connection lost for port %s — exiting for clean restart.\n", 
-            driverName, functionName, portName);
-      exit(-1);
+            "%s:%s: connection lost for port %u\n", 
+            driverName, functionName, port->amsPort);
         }
         if(!port->connectedOld && port->connected){
-          adsReadVersion(port);
+          adsReadVersion(amsClientPort,port);
         }
       }
-    }
 
     //Printout state status
     for(amsPortInfo *port : amsPortList_){
@@ -1064,6 +1122,11 @@ void adsAsynPortDriver::cyclicThread()
     if(oneAmsConnectionOK){
       notConnectedCounter_=0;
     }
+    if (notConnectedCounter_ > 5)
+    {
+      asynPrint(pasynUserSelf, ASYN_TRACE_ERROR, "cyclicThread: failed to re-establish connection to ams server... exiting ioc. will retry if on auto restart.\n");
+      exit(-1);
+    }
 
     if(!oneAmsConnectionOK && autoConnect_){
       if(oneAmsConnectionOKold_){
@@ -1071,8 +1134,9 @@ void adsAsynPortDriver::cyclicThread()
       }
       connectedAds_=0;
       if((notConnectedCounter_&2)==2){
-    asynPrint(pasynUserSelf, ASYN_TRACE_ERROR, "cyclicThread: forcing disconnect.\n");
+    asynPrint(pasynUserSelf, ASYN_TRACE_ERROR, "cyclicThread: try disconnect then reconnect.\n");
         disconnectLock(pasynUserSelf);
+        connect(pasynUserSelf);
       }
     }
     oneAmsConnectionOKold_=oneAmsConnectionOK;
@@ -1082,6 +1146,15 @@ void adsAsynPortDriver::cyclicThread()
 /* TBD - Poll at different rates depending on pollClass! */
 void adsAsynPortDriver::bulkReadThread()
 {
+  long amsClientPort = 0;
+  AdsClientPortGuard adsClientPortGuard(*this, amsClientPort);
+  if (isInvalidPortNumber(amsClientPort))
+  {
+    throw std::runtime_error(string_format(
+        "%s:%s: failed to open ads client port for this thread.\n", 
+        driverName, __func__));
+  }
+
     const char* functionName = "bulkReadThread";
     struct timeval start, now;
     uint32_t bytesRead;
@@ -1092,6 +1165,7 @@ void adsAsynPortDriver::bulkReadThread()
         usleep(1000000);
     }
     {
+  #ifdef MCB_DEBUG
         int nChunks = 0;
         int totalParams = 0;
         for (int i = 0; bulk[i].cnt; i++) {
@@ -1101,94 +1175,92 @@ void adsAsynPortDriver::bulkReadThread()
             nChunks++;
         }
         printf("bulkReadThread: TOTAL %d chunk(s), %d param slots\n", nChunks, totalParams);
+  #endif
     }
     while (1) {
-        gettimeofday(&start, NULL);
-        adsLock();
-        for (int i = 0; bulk[i].cnt; i++) {
-            // Let other threads go, otherwise we can hold the lock for many timeouts
-            adsUnlock();
-            usleep(1);
-            adsLock();
-            if (!bulkOK || !bulk[i].cnt) {
-                break;
-            }
-#ifdef MCB_DEBUG
-            static int first = 1;
-            if (first) {
-                printf("Starting to poll!\n");
-                first = 0;
-            }
-#endif
-            bytesRead = 0;
-            cnt = bulk[i].cnt;
-            readSize = bulk[i].readSize;
-            AmsAddr amsServer={remoteNetId_,bulk[i].amsPort};
-            status = AdsSyncReadWriteReqEx2(adsPort_, &amsServer,
-                                            ADSIGRP_SUMUP_READ, cnt,
-                                            readSize, bulkdata,
-                                            sizeof(bulk[i].sum[0]) * cnt, &bulk[i].sum,
-                                            &bytesRead);
-            if (status) {
-                printf("Sum read %d failed: status %ld\n", i, status);
-                continue;
-            }
-            
-            uint32_t *stat = (uint32_t *)bulkdata;
-            uint8_t  *srd  = bulkdata + cnt * sizeof(uint32_t);
-            uint64_t nTimeStamp = 0;
-            /* The first *two* bulk parameters might be the timestamp! */
-            if (!stat[0] && !stat[1] && bulk[i].sum[0].iGroup == ADSIGRP_SYM_VALBYHND) {
-                nTimeStamp = ((uint32_t *)srd)[0];
-                nTimeStamp = (nTimeStamp << 32) | ((uint32_t *)srd)[1];
-            } else {
-                /*
-                 * Sigh.  now has the time since 1970-01-01 00:00:00 UTC, but
-                 * we want 100ns increments since 1601-01-01!! So we grab the constant
-                 * from adsAsynPortDriverUtils.cpp and convert.
-                 */
-#define SEC_TO_UNIX_EPOCH 11644473600LL
-                nTimeStamp = now.tv_sec + SEC_TO_UNIX_EPOCH;
-                nTimeStamp = (nTimeStamp * 1000000 + now.tv_usec) * 10;
-            }
-            /* Always advance srd past the two timestamp data slots.
-             * SUMUP_READ writes iSize response bytes for every slot regardless
-             * of whether that slot's status is success or failure.  Skipping
-             * advancement on failure (original code) shifts srd for every
-             * subsequent param, producing zeros or garbage across the whole
-             * poll cycle whenever the timestamp handles are transiently bad. */
-            srd += bulk[i].sum[0].iSize;
-            srd += bulk[i].sum[1].iSize;
-            stat += 2;
-            for (uint32_t j = 2; j < cnt; j++) {
-                adsParamInfo *paramInfo=getAdsParamInfo(bulk[i].paramID[j]);
-                if (!paramInfo){
-                    asynPrint(asynTraceUser, ASYN_TRACE_ERROR,
-                              "%s:%s: getAdsParamInfo() for hUser %u failed\n",
-                              driverName, functionName, bulk[i].paramID[j]);
-                    continue;
-                }
-                if (*stat++) {
-                    asynPrint(asynTraceUser, ASYN_TRACE_ERROR,
-                              "%s:%s: bulk read for %s (%d) failed\n",
-                              driverName, functionName, paramInfo->drvInfo, j);
-                    exit(1);
-                }
-                paramInfo->plcTimeStampRaw=nTimeStamp;
-                paramInfo->lastCallbackSize=paramInfo->plcSize;
-                adsUpdateParameter(paramInfo, srd);
-                srd += paramInfo->lastCallbackSize;
-            }
+        {
+          std::lock_guard<std::mutex> lg(bulkReadInfoMutex_);
+          gettimeofday(&start, NULL);
+          for (int i = 0; bulk[i].cnt; i++) {
+              if (!bulkOK || !bulk[i].cnt) {
+                  break;
+              }
+  #ifdef MCB_DEBUG
+              static int first = 1;
+              if (first) {
+                  printf("Starting to poll!\n");
+                  first = 0;
+              }
+  #endif
+              bytesRead = 0;
+              cnt = bulk[i].cnt;
+              readSize = bulk[i].readSize;
+              AmsAddr amsServer={remoteNetId_,bulk[i].amsPort};
+              status = AdsSyncReadWriteReqEx2(amsClientPort, &amsServer,
+                                              ADSIGRP_SUMUP_READ, cnt,
+                                              readSize, bulkdata,
+                                              sizeof(bulk[i].sum[0]) * cnt, &bulk[i].sum,
+                                              &bytesRead);
+              if (status) {
+                  printf("Sum read %d failed: status %ld\n", i, status);
+                  continue;
+              }
+              
+              uint32_t *stat = (uint32_t *)bulkdata;
+              uint8_t  *srd  = bulkdata + cnt * sizeof(uint32_t);
+              uint64_t nTimeStamp = 0;
+              /* The first *two* bulk parameters might be the timestamp! */
+              if (!stat[0] && !stat[1] && bulk[i].sum[0].iGroup == ADSIGRP_SYM_VALBYHND) {
+                  nTimeStamp = ((uint32_t *)srd)[0];
+                  nTimeStamp = (nTimeStamp << 32) | ((uint32_t *)srd)[1];
+              } else {
+                  /*
+                  * Sigh.  now has the time since 1970-01-01 00:00:00 UTC, but
+                  * we want 100ns increments since 1601-01-01!! So we grab the constant
+                  * from adsAsynPortDriverUtils.cpp and convert.
+                  */
+  #define SEC_TO_UNIX_EPOCH 11644473600LL
+                  nTimeStamp = now.tv_sec + SEC_TO_UNIX_EPOCH;
+                  nTimeStamp = (nTimeStamp * 1000000 + now.tv_usec) * 10;
+              }
+              /* Always advance srd past the two timestamp data slots.
+              * SUMUP_READ writes iSize response bytes for every slot regardless
+              * of whether that slot's status is success or failure.  Skipping
+              * advancement on failure (original code) shifts srd for every
+              * subsequent param, producing zeros or garbage across the whole
+              * poll cycle whenever the timestamp handles are transiently bad. */
+              srd += bulk[i].sum[0].iSize;
+              srd += bulk[i].sum[1].iSize;
+              stat += 2;
+              for (uint32_t j = 2; j < cnt; j++) {
+                  auto paramInfo=getAdsParamInfo(bulk[i].paramID[j]);
+                  if (!paramInfo){
+                      asynPrint(asynTraceUser, ASYN_TRACE_ERROR,
+                                "%s:%s: getAdsParamInfo() for hUser %u failed\n",
+                                driverName, functionName, bulk[i].paramID[j]);
+                      continue;
+                  }
+                  if (*stat++) {
+                      asynPrint(asynTraceUser, ASYN_TRACE_ERROR,
+                                "%s:%s: bulk read for %s (%d) failed\n",
+                                driverName, functionName, paramInfo->drvInfo, j);
+                      paramInfo->refreshNeeded = true;
+                  }
+                  paramInfo->plcTimeStampRaw=nTimeStamp;
+                  paramInfo->lastCallbackSize=paramInfo->plcSize;
+                  adsUpdateParameterLock(paramInfo, srd);
+                  srd += paramInfo->lastCallbackSize;
+              }
+          }
         }
-        adsUnlock();
         gettimeofday(&now, NULL);
         bulk_elapsed_us = (now.tv_sec - start.tv_sec) * 1000000 + 
                       (now.tv_usec - start.tv_usec);
-//#ifdef MCB_DEBUG
+#ifdef MCB_DEBUG
         printf("ELAPSED: %g\n", bulk_elapsed_us / 1000000.0);
-//#endif
-        // Always sleep at least 1 to let other threads acquire the ads lock
-        usleep(std::max(bulk_delay_us - bulk_elapsed_us, 1));
+#endif
+        // Always sleep at least 10ms
+        usleep(std::max(bulk_delay_us - bulk_elapsed_us, 10000));
     }
 }
 
@@ -1213,6 +1285,23 @@ void adsAsynPortDriver::dataCallbackThread()
         free(info->data);
         datacbqueue.pop();
     }
+}
+
+// All IO Intr callbacks must be generated from this single thread.
+void adsAsynPortDriver::triggerEpicsIoIntrCallbacksThread()
+{
+  asynPrint(pasynUserSelf, ASYN_TRACE_FLOW, "%s:%s:\n", driverName, __func__);
+  while (true)
+  {
+    if (!allowCallbackEpicsState)
+    {
+      epicsThreadSleep(0.5);
+      continue;
+    }
+    // Batch callback calls into 100 ms intervals
+    fireAllCallbacksLock();
+    usleep(100000);
+  }
 }
 
 
@@ -1254,11 +1343,7 @@ void adsAsynPortDriver::report(FILE *fp, int details)
     //print all parameters
     fprintf(fp,"Parameter details:\n");
     for(int i=0; i<adsParamArrayCount_;i++){
-      if(!pAdsParamArray_[i]){
-        fprintf(fp,"%s:%s: ERROR: Parameter array null at index %d\n", driverName, functionName,i);
-        return;
-      }
-      adsParamInfo *paramInfo=pAdsParamArray_[i];
+      auto paramInfo=&adsParamArray_[i];
       fprintf(fp,"  Parameter %d:\n",i);
       if(i==0){
         fprintf(fp,"    Parameter 0 (pasynUser->reason==0) is reserved for Asyn octet interface (Motor Record and Stream Device access).\n");
@@ -1329,17 +1414,23 @@ asynStatus adsAsynPortDriver::disconnect(asynUser *pasynUser)
   if (disconnectStatus){
     return asynError;
   }
+  
+  connectedAds_ = 0;
 
-  return asynPortDriver::disconnect(pasynUser);
+  if(asynPortDriver::disconnect(pasynUser)!=asynSuccess){
+    return asynError;
+  }
+
+  return asynSuccess;
 }
 
 /** Refreshes the parameters that need refresh after a reconnect or a
  * connection failure to a ams port.
  * \return asynSuccess or asynError.
  */
-asynStatus adsAsynPortDriver::refreshParams()
+asynStatus adsAsynPortDriver::refreshParams(uint16_t amsClientPort)
 {
-  return refreshParams(0);
+  return refreshParams(amsClientPort,0);
 }
 
 /** Refreshes all parameters for a specific amsport (with asyn lock()).
@@ -1347,11 +1438,10 @@ asynStatus adsAsynPortDriver::refreshParams()
  * \return asynSuccess or asynError.
  * Thread safe.
  */
-
-asynStatus adsAsynPortDriver::refreshParamsLock(uint16_t amsPort)
+asynStatus adsAsynPortDriver::refreshParamsLock(uint16_t amsClientPort, uint16_t amsPort)
 {
   lock();
-  asynStatus stat=refreshParams(amsPort);
+  asynStatus stat=refreshParams(amsClientPort,amsPort);
   unlock();
   return stat;
 }
@@ -1360,7 +1450,7 @@ asynStatus adsAsynPortDriver::refreshParamsLock(uint16_t amsPort)
  * \param[in] amsPort ams port.
  * \return asynSuccess or asynError.
  */
-asynStatus adsAsynPortDriver::refreshParams(uint16_t amsPort)
+asynStatus adsAsynPortDriver::refreshParams(uint16_t amsClientPort, uint16_t amsPort)
 {
   const char* functionName = "refreshParams";
   asynPrint(pasynUserSelf,ASYN_TRACE_FLOW, "%s:%s:\n", driverName, functionName);
@@ -1369,12 +1459,9 @@ asynStatus adsAsynPortDriver::refreshParams(uint16_t amsPort)
     if(adsParamArrayCount_>1){
       //Renew data notification callbacks
       for(int i=1; i<adsParamArrayCount_;i++){  //Skip first param since used for motorrecord or stream device
-        if(!pAdsParamArray_[i]){
-          continue;
-        }
-        adsParamInfo *paramInfo=pAdsParamArray_[i];
+        auto paramInfo=&adsParamArray_[i];
         if((amsPort==0 || paramInfo->amsPort==amsPort) && paramInfo->refreshNeeded){
-          updateParamInfoWithPLCInfo(paramInfo);
+          updateParamInfoWithPLCInfo(amsClientPort,paramInfo);
         }
       }
     }
@@ -1383,9 +1470,9 @@ asynStatus adsAsynPortDriver::refreshParams(uint16_t amsPort)
     for(amsPortInfo *port : amsPortList_){
       if(port->amsPort==amsPort && port->refreshNeeded){
         if(port->bCallbackNotifyValid){
-          adsDelSymbolsChangedCallback(port);
+          adsDelSymbolsChangedCallback(amsClientPort,port);
         }
-        adsAddSymbolsChangedCallback(port);
+        adsAddSymbolsChangedCallback(amsClientPort,port);
       }
     }
   }
@@ -1418,10 +1505,7 @@ asynStatus adsAsynPortDriver::invalidateParams(uint16_t amsPort)
   bulkOK = 0;
   if(adsParamArrayCount_>1){
     for(int i=1; i<adsParamArrayCount_;i++){  //Skip first param since used for motorrecord or stream device
-      if(!pAdsParamArray_[i]){
-        continue;
-      }
-      adsParamInfo *paramInfo=pAdsParamArray_[i];
+      auto paramInfo=&adsParamArray_[i];
       if(amsPort==0 || paramInfo->amsPort==amsPort){
         paramInfo->refreshNeeded=true;
       }
@@ -1462,8 +1546,17 @@ asynStatus adsAsynPortDriver::connect(asynUser *pasynUser)
   const char* functionName = "connect";
   asynPrint(pasynUser, ASYN_TRACE_FLOW, "%s:%s: %s\n", driverName, functionName, epicsThreadGetNameSelf());
 
+  long amsClientPort = 0;
+  AdsClientPortGuard adsClientPortGuard(*this, amsClientPort);
+  if (isInvalidPortNumber(amsClientPort))
+  {
+    throw std::runtime_error(string_format(
+        "%s:%s: failed to open ads client port for this thread.\n", 
+        driverName, __func__));
+  }
+
   bool err=false;
-  asynStatus stat = adsConnect();
+  asynStatus stat = adsConnect(amsClientPort);
 
   if (stat!= asynSuccess){
     return asynError;
@@ -1527,6 +1620,15 @@ asynStatus adsAsynPortDriver::drvUserCreate(asynUser *pasynUser,const char *drvI
   const char* functionName = "drvUserCreate";
   static int vcnt = 0;
 
+  long amsClientPort = 0;
+  AdsClientPortGuard adsClientPortGuard(*this, amsClientPort);
+  if (isInvalidPortNumber(amsClientPort))
+  {
+    throw std::runtime_error(string_format(
+        "%s:%s: failed to open ads client port for this thread.\n", 
+        driverName, __func__));
+  }
+
   /* One-off: resolve all symbol info from TwinCAT on first call
    * resolveSymbolInfo() runs after dbLoadRecords() has populated pdbbase
    * so that buildDrvInfoCache() finds all records.
@@ -1535,7 +1637,7 @@ asynStatus adsAsynPortDriver::drvUserCreate(asynUser *pasynUser,const char *drvI
   */
   if (!symInfoResolved_ && connectedAds_) {
       symInfoResolved_ = true;   /* set before call to prevent re-entry */
-      if (resolveSymbolInfo() != asynSuccess) {
+      if (resolveSymbolInfo(amsClientPort) != asynSuccess) {
           asynPrint(pasynUser, ASYN_TRACE_ERROR,
                     "%s:%s: resolveSymbolInfo failed — "
                     "falling back to per-record ADS calls\n",
@@ -1543,7 +1645,7 @@ asynStatus adsAsynPortDriver::drvUserCreate(asynUser *pasynUser,const char *drvI
       }
       /* now resolve handles for everything we just populated */
       if (!symbolDict_.empty()) {
-          if (resolveSymbolHandles() != asynSuccess) {
+          if (resolveSymbolHandles(amsClientPort) != asynSuccess) {
               asynPrint(pasynUser, ASYN_TRACE_ERROR,
                         "%s:%s: resolveSymbolHandles failed\n",
                         driverName, functionName);
@@ -1563,15 +1665,6 @@ asynStatus adsAsynPortDriver::drvUserCreate(asynUser *pasynUser,const char *drvI
   asynStatus status=findParam(drvInfo,&index);
   if(status==asynSuccess){
     asynPrint(pasynUser, ASYN_TRACE_FLOW, "%s:%s: Parameter index found at: %d for %s. \n", driverName, functionName,index,drvInfo);
-    if(!pAdsParamArray_[index]){
-      asynPrint(pasynUser, ASYN_TRACE_ERROR, "%s:%s:pAdsParamArray_[%d]==NULL (drvInfo=%s).", driverName, functionName,index,drvInfo);
-      return asynError;
-    }
-
-    if(pAdsParamArray_[index]->dataSource==ADS_DATASOURCE_AMS_STATE){ //Local variable (not in PLC) like AMS port state.
-      return asynPortDriver::drvUserCreate(pasynUser,drvInfo,pptypeName,psize);
-    }
-
     return asynPortDriver::drvUserCreate(pasynUser,drvInfo,pptypeName,psize);
   }
 
@@ -1590,13 +1683,19 @@ asynStatus adsAsynPortDriver::drvUserCreate(asynUser *pasynUser,const char *drvI
   }
 
   // Collect data from drvInfo string and recordpasynUser->reason=index;
-  adsParamInfo *paramInfo=new adsParamInfo();
-  memset(paramInfo,0,sizeof(adsParamInfo));
+  auto paramInfo=&adsParamArray_[adsParamArrayCount_];
   paramInfo->sampleTimeMS=defaultSampleTimeMS_;
   paramInfo->maxDelayTimeMS=defaultMaxDelayTimeMS_;
   paramInfo->refreshNeeded=1;
   paramInfo->bulkIndex = -1;
   paramInfo->bulkOffset = -1;
+
+  status=parsePlcInfofromDrvInfo(drvInfo,paramInfo);
+  if(status!=asynSuccess){
+    return asynError;
+  }
+
+  paramInfo->drvInfo = strdup(drvInfo);
 
   status=getRecordInfoFromDrvInfo(drvInfo, paramInfo);
   if(status!=asynSuccess){
@@ -1635,13 +1734,7 @@ asynStatus adsAsynPortDriver::drvUserCreate(asynUser *pasynUser,const char *drvI
 
   paramInfo->asynAddr=addr;
 
-  status=parsePlcInfofromDrvInfo(drvInfo,paramInfo);
-  if(status!=asynSuccess){
-    return asynError;
-  }
   pasynUser->timeout=(paramInfo->maxDelayTimeMS*2)/1000;
-
-  pAdsParamArray_[adsParamArrayCount_]=paramInfo;
   adsParamArrayCount_++;
 
   if(!connectedAds_){
@@ -1650,7 +1743,7 @@ asynStatus adsAsynPortDriver::drvUserCreate(asynUser *pasynUser,const char *drvI
   }
 
   if(connectedAds_ && !(paramInfo->dataSource==ADS_DATASOURCE_AMS_STATE)){  //Do not read info from PLC if local variable (like ams-port state)
-    status=updateParamInfoWithPLCInfo(paramInfo);
+    status=updateParamInfoWithPLCInfo(amsClientPort, paramInfo);
     if(status!=asynSuccess){
       return asynError;
     }
@@ -1671,7 +1764,7 @@ asynStatus adsAsynPortDriver::drvUserCreate(asynUser *pasynUser,const char *drvI
  * If the PLC variable is an array then a buffer is allocated in the paramInfo to
  * hold the information.
  */
-asynStatus adsAsynPortDriver::updateParamInfoWithPLCInfo(adsParamInfo *paramInfo)
+asynStatus adsAsynPortDriver::updateParamInfoWithPLCInfo(uint16_t amsClientPort, adsParamInfo *paramInfo)
 {
   const char* functionName = "updateParamInfoWithPLCInfo";
   asynPrint(pasynUserSelf,ASYN_TRACE_FLOW, "%s:%s: : %s\n", driverName, functionName,paramInfo->drvInfo);
@@ -1708,7 +1801,7 @@ asynStatus adsAsynPortDriver::updateParamInfoWithPLCInfo(adsParamInfo *paramInfo
   }
 
   if (!paramInfo->isAdrCommand && !fromDict) {
-    status = adsGetSymInfoByName(paramInfo);
+    status = adsGetSymInfoByName(amsClientPort, paramInfo);
     if (status != asynSuccess)
       return asynError;
   }
@@ -1758,8 +1851,8 @@ asynStatus adsAsynPortDriver::updateParamInfoWithPLCInfo(adsParamInfo *paramInfo
   /* Handle already set by resolveSymbolHandles() for dict symbols.
    * For misses (ADR commands, locals, fallback), acquire individually. */
   if (!paramInfo->isAdrCommand && !fromDict) {
-      adsReleaseSymbolicHandle(paramInfo, true);
-      status = adsGetSymHandleByName(paramInfo);
+      adsReleaseSymbolicHandle(amsClientPort, paramInfo, true);
+      status = adsGetSymHandleByName(amsClientPort, paramInfo);
       if (status != asynSuccess)
           return asynError;
   }
@@ -1767,13 +1860,13 @@ asynStatus adsAsynPortDriver::updateParamInfoWithPLCInfo(adsParamInfo *paramInfo
   if(paramInfo->isIOIntr){
       /* If it's not a bulk read or if it's really big, just subscribe to it! */
       if (!paramInfo->isBulkRead || paramInfo->plcSize > 1024*1024) {
-          adsDelDataCallback(paramInfo,true);   //try to delete
-          status=adsAddDataCallback(paramInfo);
+          adsDelDataCallback(amsClientPort, paramInfo,true);   //try to delete
+          status=adsAddDataCallback(amsClientPort, paramInfo);
           if(status!=asynSuccess){
               return asynError;
           }
       } else { /* Otherwise, put it in a bulk read! */
-      status=adsAddToBulkRead(paramInfo);
+      status=adsAddToBulkRead(amsClientPort, paramInfo);
           if(status!=asynSuccess){
               return asynError;
           }
@@ -1813,9 +1906,9 @@ void adsAsynPortDriver::poll_info(char *name)
 }
 
 /* TBD - Use paramInfo->pollClass to separate into different poll rates!! */
-asynStatus adsAsynPortDriver::adsAddToBulkRead(adsParamInfo* paramInfo)
+asynStatus adsAsynPortDriver::adsAddToBulkRead(uint16_t amsClientPort,adsParamInfo* paramInfo)
 {
-    adsLock(); // Prevent reads while we change this!
+  std::lock_guard<std::mutex> lg(bulkReadInfoMutex_);
     if (paramInfo->bulkIndex < 0) { /* Not assigned yet, find one! */
         int i;
         for (i = 0; i < MAXBULK; i++) {
@@ -1825,12 +1918,11 @@ asynStatus adsAsynPortDriver::adsAddToBulkRead(adsParamInfo* paramInfo)
                 break;
         }
         if (i == MAXBULK) {
-            adsUnlock();
             return asynError; // No room at the inn.
         }
         if (!bulk[i].cnt) { // First variable in this bulk request!
             bulk[i].amsPort = paramInfo->amsPort;
-            int j = adsFindBulkTimeStamp(paramInfo->amsPort);
+            int j = adsFindBulkTimeStamp(amsClientPort, paramInfo->amsPort);
             if (bulkTS[j].refreshNeeded) { /* No TS variables!! */
                 bulk[i].sum[0].iGroup  = 0x4020; // %M
                 bulk[i].sum[0].iOffset = 0;
@@ -1867,12 +1959,12 @@ asynStatus adsAsynPortDriver::adsAddToBulkRead(adsParamInfo* paramInfo)
     bulk[paramInfo->bulkIndex].sum[paramInfo->bulkOffset].iOffset = offset;
     bulk[paramInfo->bulkIndex].sum[paramInfo->bulkOffset].iSize   = paramInfo->plcSize;
     bulk[paramInfo->bulkIndex].readSize += paramInfo->plcSize + sizeof(uint32_t);
-    adsUnlock();
+    
     return asynSuccess;
 }
 
 // Assume locked!!
-int adsAsynPortDriver::adsFindBulkTimeStamp(uint16_t amsPort)
+int adsAsynPortDriver::adsFindBulkTimeStamp(uint16_t amsClientPort, uint16_t amsPort)
 {
     int i;
     for (i = 0; i < bulkTScnt; i++) {
@@ -1889,14 +1981,14 @@ int adsAsynPortDriver::adsFindBulkTimeStamp(uint16_t amsPort)
     if (bulkTS[i].refreshNeeded) {
         long statL, statH;
         AmsAddr amsServer = {remoteNetId_, amsPort};
-        statH = AdsSyncReadWriteReqEx2(adsPort_,
+        statH = AdsSyncReadWriteReqEx2(amsClientPort,
                                        &amsServer,
                                        ADSIGRP_SYM_HNDBYNAME,
                                        0,
                                        sizeof(uint32_t), &bulkTS[i].iHandleH,
                                        strlen(TSHI), TSHI, 
                                        nullptr);
-        statL = AdsSyncReadWriteReqEx2(adsPort_,
+        statL = AdsSyncReadWriteReqEx2(amsClientPort,
                                        &amsServer,
                                        ADSIGRP_SYM_HNDBYNAME,
                                        0,
@@ -1920,7 +2012,7 @@ asynStatus adsAsynPortDriver::getRecordInfoFromDrvInfo(const char *drvInfo,adsPa
   const char* functionName = "getRecordInfoFromDrvInfo";
   asynPrint(pasynUserSelf,ASYN_TRACE_FLOW, "%s:%s: drvInfo: %s\n", driverName, functionName,drvInfo);
 
-  paramInfo->amsPort = amsportDefault_;
+  paramInfo->amsPort = amsportDefault_; // will need to improve this later to use ams server port of param.
 
   /* Build cache on first call — O(N) scan of entire database, done once. */
   buildDrvInfoCache();
@@ -2274,13 +2366,22 @@ asynStatus adsAsynPortDriver::readOctet(asynUser *pasynUser, char *value, size_t
   const char* functionName = "readOctet";
   asynPrint(pasynUser, ASYN_TRACE_FLOW, "%s:%s:\n", driverName, functionName);
 
+  long amsClientPort = 0;
+  AdsClientPortGuard adsClientPortGuard(*this, amsClientPort);
+  if (isInvalidPortNumber(amsClientPort))
+  {
+    throw std::runtime_error(string_format(
+        "%s:%s: failed to open ads client port for this thread.\n", 
+        driverName, __func__));
+  }
+
   size_t thisRead = 0;
   int reason = 0;
   asynStatus status = asynSuccess;
 
   *value = '\0';
   lock();
-  int error=octetCMDreadIt(value, maxChars);
+  int error=octetCMDreadIt(amsClientPort, value, maxChars);
   if (error) {
     status = asynError;
     asynPrint(pasynUser, ASYN_TRACE_ERROR,
@@ -2327,7 +2428,7 @@ asynStatus adsAsynPortDriver::readOctet(asynUser *pasynUser, char *value, size_t
  *
  * \return 0 for success or error code.
  */
-int adsAsynPortDriver::octetCMDreadIt(char *outbuf, size_t outlen)
+int adsAsynPortDriver::octetCMDreadIt(uint16_t amsClientPort, char *outbuf, size_t outlen)
 {
   const char* functionName = "octetCMDreadIt";
   asynPrint(pasynUserSelf,ASYN_TRACE_FLOW, "%s:%s: Buffer: %s, size: %d\n", driverName, functionName,outbuf,(int)outlen);
@@ -2379,6 +2480,15 @@ asynStatus adsAsynPortDriver::writeOctet(asynUser *pasynUser, const char *value,
   const char* functionName = "writeOctet";
   asynPrint(pasynUser, ASYN_TRACE_FLOW, "%s:%s: %s\n", driverName, functionName,value);
 
+  long amsClientPort = 0;
+  AdsClientPortGuard adsClientPortGuard(*this, amsClientPort);
+  if (isInvalidPortNumber(amsClientPort))
+  {
+    throw std::runtime_error(string_format(
+        "%s:%s: failed to open ads client port for this thread.\n", 
+        driverName, __func__));
+  }
+
   size_t thisWrite = 0;
   asynStatus status = asynError;
 
@@ -2393,8 +2503,8 @@ asynStatus adsAsynPortDriver::writeOctet(asynUser *pasynUser, const char *value,
   if (maxChars == 0){
     return asynSuccess;
   }
-  //lock();
-  int errorCode=octetCMDwriteIt(value, maxChars);
+
+  int errorCode=octetCMDwriteIt(amsClientPort, value, maxChars);
   if (errorCode){
     /*Return asyn error if communication is down (all client errors) otherwise asynSuccess
      * but error message in buffer*/
@@ -2406,7 +2516,6 @@ asynStatus adsAsynPortDriver::writeOctet(asynUser *pasynUser, const char *value,
   thisWrite = maxChars;
   *nActual = thisWrite;
 
-  //unlock();
   asynPrint(pasynUser, ASYN_TRACE_FLOW,
             "%s wrote %lu return %s.\n",
             portName,
@@ -2422,7 +2531,7 @@ asynStatus adsAsynPortDriver::writeOctet(asynUser *pasynUser, const char *value,
  *
  * \return 0 for success or error code.
  */
-int adsAsynPortDriver::octetCMDwriteIt(const char *inbuf, size_t inlen)
+int adsAsynPortDriver::octetCMDwriteIt(uint16_t amsClientPort, const char *inbuf, size_t inlen)
 {
   const char* functionName = "octetCMDwriteIt";
   asynPrint(pasynUserSelf,ASYN_TRACE_FLOW, "%s:%s: Write command: %s, length: %d\n", driverName, functionName,inbuf,(int) inlen);
@@ -2448,7 +2557,7 @@ int adsAsynPortDriver::octetCMDwriteIt(const char *inbuf, size_t inlen)
     }
   }
 
-  errorCode = octetCmdHandleInputLine(new_buf,&octetAsciiBuffer_);
+  errorCode = octetCmdHandleInputLine(amsClientPort,new_buf,&octetAsciiBuffer_);
   free(new_buf);
 
   octetCmdBuf_printf(&octetAsciiBuffer_,"%s%s",had_cr ? "\r" : "", had_lf ? "\n" : "");
@@ -2456,7 +2565,7 @@ int adsAsynPortDriver::octetCMDwriteIt(const char *inbuf, size_t inlen)
   return errorCode;
 }
 
-int adsAsynPortDriver::octetCmdHandleInputLine(const char *input_line, adsOctetOutputBufferType *buffer)
+int adsAsynPortDriver::octetCmdHandleInputLine(uint16_t amsClientPort, const char *input_line, adsOctetOutputBufferType *buffer)
 {
   const char* functionName = "octetCmdHandleInputLine";
   asynPrint(pasynUserSelf,ASYN_TRACE_FLOW, "%s:%s: Input line: %s\n", driverName, functionName,input_line);
@@ -2469,7 +2578,7 @@ int adsAsynPortDriver::octetCmdHandleInputLine(const char *input_line, adsOctetO
 
   int errorCodeLatch =0;
   for (int i = 1; i <= argc; i++) {
-    int errorCode = octetMotorHandleOneArg(my_argv[i],buffer);  //Continue with next cmd even if error
+    int errorCode = octetMotorHandleOneArg(amsClientPort, my_argv[i],buffer);  //Continue with next cmd even if error
     if(errorCode && !errorCodeLatch){ //latch first error code for stacked commands
       errorCodeLatch=errorCode;
     }
@@ -2495,7 +2604,7 @@ int adsAsynPortDriver::octetCmdHandleInputLine(const char *input_line, adsOctetO
  *
  * \return 0 for success or error code.
  */
-int adsAsynPortDriver::octetMotorHandleOneArg(const char *myarg_1,adsOctetOutputBufferType *buffer)
+int adsAsynPortDriver::octetMotorHandleOneArg(uint16_t amsClientPort,const char *myarg_1,adsOctetOutputBufferType *buffer)
 {
   const char* functionName = "octetMotorHandleOneArg";
   asynPrint(pasynUserSelf,ASYN_TRACE_FLOW, "%s:%s: Command: %s\n", driverName, functionName,myarg_1);
@@ -2533,7 +2642,7 @@ int adsAsynPortDriver::octetMotorHandleOneArg(const char *myarg_1,adsOctetOutput
   if(adr) {
     myarg_1 = adr;
 
-    err_code = octetMotorHandleADRCmd(myarg_1,amsPort,buffer);
+    err_code = octetMotorHandleADRCmd(amsClientPort, myarg_1,amsPort,buffer);
     if (err_code == -1 || err_code == 0) {
       return 0;
     }
@@ -2550,7 +2659,7 @@ int adsAsynPortDriver::octetMotorHandleOneArg(const char *myarg_1,adsOctetOutput
     //Copy variable name
     strncpy(variableName,myarg_1,adr-myarg_1);
     adr++; //Jump over '='
-    err_code = octetAdsWriteByName(amsPort,variableName,adr,buffer);
+    err_code = octetAdsWriteByName(amsClientPort, amsPort,variableName,adr,buffer);
     if (err_code) {
       OCTET_RETURN_ERROR(buffer,err_code,"%s",adsErrorToString(err_code));
     }
@@ -2565,7 +2674,7 @@ int adsAsynPortDriver::octetMotorHandleOneArg(const char *myarg_1,adsOctetOutput
     //Copy variable name
     strncpy(variableName,myarg_1,adr-myarg_1);
     variableName[adr-myarg_1]=0;
-    err_code = octetAdsReadByName(amsPort,variableName,buffer);
+    err_code = octetAdsReadByName(amsClientPort, amsPort,variableName,buffer);
     if (err_code) {
       OCTET_RETURN_ERROR(buffer,err_code,"%s",adsErrorToString(err_code));
     }
@@ -2587,7 +2696,7 @@ int adsAsynPortDriver::octetMotorHandleOneArg(const char *myarg_1,adsOctetOutput
  *
  * \note:  see octetAdsWriteByGroupOffset for more information.\n
  */
-int adsAsynPortDriver::octetMotorHandleADRCmd(const char *arg, uint16_t amsport,adsOctetOutputBufferType *buffer)
+int adsAsynPortDriver::octetMotorHandleADRCmd(uint16_t amsClientPort, const char *arg, uint16_t amsport,adsOctetOutputBufferType *buffer)
 {
   const char* functionName = "octetMotorHandleADRCmd";
   asynPrint(pasynUserSelf,ASYN_TRACE_FLOW, "%s:%s: Command: %s, amsPort: %d\n",driverName,functionName,arg,(int)amsport);
@@ -2624,7 +2733,7 @@ int adsAsynPortDriver::octetMotorHandleADRCmd(const char *arg, uint16_t amsport,
   if (myarg_1) {
     myarg_1++; /* Jump over '=' */
 
-    int error=octetAdsWriteByGroupOffset(amsport,(uint32_t)group_no,(uint32_t) offset_in_group,(uint16_t)type_in_PLC,(uint32_t)len_in_PLC,myarg_1,buffer);
+    int error=octetAdsWriteByGroupOffset(amsClientPort, amsport,(uint32_t)group_no,(uint32_t) offset_in_group,(uint16_t)type_in_PLC,(uint32_t)len_in_PLC,myarg_1,buffer);
     if (error){
       OCTET_RETURN_ERROR(buffer,error,"%s",adsErrorToString(error));
     }
@@ -2643,7 +2752,7 @@ int adsAsynPortDriver::octetMotorHandleADRCmd(const char *arg, uint16_t amsport,
     info.iGroup=group_no;
     info.iOffset=offset_in_group;
 
-    int error=octetAdsReadByGroupOffset(amsport,&info,buffer);
+    int error=octetAdsReadByGroupOffset(amsClientPort, amsport,&info,buffer);
     if (error){
       OCTET_RETURN_ERROR(buffer,error,"%s",adsErrorToString(error));
     }
@@ -2661,7 +2770,7 @@ int adsAsynPortDriver::octetMotorHandleADRCmd(const char *arg, uint16_t amsport,
  *
  * \return 0 for success or error code.
  */
-int adsAsynPortDriver::octetAdsReadByName(uint16_t amsPort,const char *variableAddr,adsOctetOutputBufferType* outBuffer)
+int adsAsynPortDriver::octetAdsReadByName(uint16_t amsClientPort, uint16_t amsPort,const char *variableAddr,adsOctetOutputBufferType* outBuffer)
 {
   const char* functionName = "octetAdsReadByName";
   asynPrint(pasynUserSelf,ASYN_TRACE_FLOW, "%s:%s: Variable:%s, amsPort %u\n", driverName, functionName,variableAddr,amsPort);
@@ -2670,12 +2779,12 @@ int adsAsynPortDriver::octetAdsReadByName(uint16_t amsPort,const char *variableA
   memset(&infoStruct,0,sizeof(infoStruct));
 
   long errorCode=0;
-  asynStatus stat=adsGetSymInfoByName(amsPort,variableAddr,&infoStruct,&errorCode);
+  asynStatus stat=adsGetSymInfoByName(amsClientPort,amsPort,variableAddr,&infoStruct,&errorCode);
   if (stat!=asynSuccess) {
     return errorCode;
   }
 
-  return octetAdsReadByGroupOffset(amsPort,&infoStruct,outBuffer);
+  return octetAdsReadByGroupOffset(amsClientPort,amsPort,&infoStruct,outBuffer);
 }
 
 /** Write a variable to PLC by symbolic addressing.\
@@ -2688,7 +2797,7 @@ int adsAsynPortDriver::octetAdsReadByName(uint16_t amsPort,const char *variableA
  *
  * \return 0 for success or error code.
  */
-int adsAsynPortDriver::octetAdsWriteByName(uint16_t amsPort,const char *variableAddr,const char *asciiValueToWrite,adsOctetOutputBufferType *outBuffer)
+int adsAsynPortDriver::octetAdsWriteByName(uint16_t amsClientPort,uint16_t amsPort,const char *variableAddr,const char *asciiValueToWrite,adsOctetOutputBufferType *outBuffer)
 {
   const char* functionName = "octetAdsWriteByName";
   asynPrint(pasynUserSelf,ASYN_TRACE_FLOW, "%s:%s: Variable: %s, value: %s.\n", driverName, functionName,variableAddr,asciiValueToWrite);
@@ -2697,12 +2806,12 @@ int adsAsynPortDriver::octetAdsWriteByName(uint16_t amsPort,const char *variable
   memset(&infoStruct,0,sizeof(infoStruct));
 
   long errorCode=0;
-  asynStatus stat=adsGetSymInfoByName(amsPort,variableAddr,&infoStruct,&errorCode);
+  asynStatus stat=adsGetSymInfoByName(amsClientPort,amsPort,variableAddr,&infoStruct,&errorCode);
   if (stat!=asynSuccess) {
     return errorCode;
   }
 
- return octetAdsWriteByGroupOffset(amsPort,infoStruct.iGroup,infoStruct.iOffset,infoStruct.dataType,infoStruct.size,asciiValueToWrite,outBuffer);
+ return octetAdsWriteByGroupOffset(amsClientPort,amsPort,infoStruct.iGroup,infoStruct.iOffset,infoStruct.dataType,infoStruct.size,asciiValueToWrite,outBuffer);
 }
 
 /**Read a variable from PLC by absolute addressing.\
@@ -2714,7 +2823,7 @@ int adsAsynPortDriver::octetAdsWriteByName(uint16_t amsPort,const char *variable
  *
  * \return 0 for success or error code.
  */
-int adsAsynPortDriver::octetAdsReadByGroupOffset(uint16_t amsPort,adsSymbolEntry *info, adsOctetOutputBufferType *outBuffer)
+int adsAsynPortDriver::octetAdsReadByGroupOffset(uint16_t amsClientPort,uint16_t amsPort,adsSymbolEntry *info, adsOctetOutputBufferType *outBuffer)
 {
   const char* functionName = "octetAdsReadByGroupOffset";
   asynPrint(pasynUserSelf,ASYN_TRACE_FLOW, "%s:%s: amsPort: %d, group: %d, offset: %d, dataType: %s (%d), dataSize: %d.\n", driverName, functionName,(int)amsPort,(int)info->iGroup,(int)info->iOffset,adsTypeToString(info->dataType),(int)info->dataType,(int)info->size);
@@ -2728,24 +2837,21 @@ int adsAsynPortDriver::octetAdsReadByGroupOffset(uint16_t amsPort,adsSymbolEntry
     asynPrint(pasynUserSelf, ASYN_TRACE_WARNING, "%s:%s: Read buffer size smaller than size in plc.\n", driverName, functionName);
   }
 
-  adsLock();
   memset(&octetBinaryBuffer_,0,ADS_CMD_BUFFER_SIZE);
 
-  int error = AdsSyncReadReqEx2(adsPort_, &amsServer, info->iGroup,info->iOffset,dataSize, &octetBinaryBuffer_, &bytesRead);
+  int error = AdsSyncReadReqEx2(amsClientPort, &amsServer, info->iGroup,info->iOffset,dataSize, &octetBinaryBuffer_, &bytesRead);
 
   if (error) {
     asynPrint(pasynUserSelf, ASYN_TRACE_ERROR, "%s:%s: ADS read failed with: %s (0x%x).\n", driverName, functionName,adsErrorToString(error),error);
-    adsUnlock();
     return error;
   }
 
   error=octetBinary2ascii(octetReturnVarName_,&octetBinaryBuffer_,ADS_CMD_BUFFER_SIZE,info,outBuffer);
   if (error) {
     asynPrint(pasynUserSelf, ASYN_TRACE_ERROR, "%s:%s: Binary to ASCII conversion failed with: %d\n", driverName, functionName,error);
-    adsUnlock();
     return error;
   }
-  adsUnlock();
+
   return 0;
 }
 
@@ -2783,7 +2889,7 @@ int adsAsynPortDriver::octetAdsReadByGroupOffset(uint16_t amsPort,adsSymbolEntry
  *   The data will be considered to be an array if dataSize is bigger than the\n
  *   size of the the type.
  */
-int adsAsynPortDriver::octetAdsWriteByGroupOffset(uint16_t amsPort,uint32_t group, uint32_t offset,uint16_t dataType,uint32_t dataSize, const char *asciiValueToWrite,adsOctetOutputBufferType *asciiResponseBuffer)
+int adsAsynPortDriver::octetAdsWriteByGroupOffset(uint16_t amsClientPort,uint16_t amsPort,uint32_t group, uint32_t offset,uint16_t dataType,uint32_t dataSize, const char *asciiValueToWrite,adsOctetOutputBufferType *asciiResponseBuffer)
 {
   const char* functionName = "octetAdsWriteByGroupOffset";
   asynPrint(pasynUserSelf,ASYN_TRACE_FLOW, "%s:%s: amsPort: %d, group: %d, offset: %d, dataType: %s (%d), dataSize: %d.\n", driverName, functionName,(int)amsPort,(int)group,(int)offset,adsTypeToString(dataType),(int)dataType,(int)dataSize);
@@ -2791,12 +2897,10 @@ int adsAsynPortDriver::octetAdsWriteByGroupOffset(uint16_t amsPort,uint32_t grou
   uint32_t bytesToWrite=0;
   AmsAddr amsServer={remoteNetId_,amsPort};
 
-  adsLock();
   memset(&octetBinaryBuffer_,0,ADS_CMD_BUFFER_SIZE);
 
   int error=octetAscii2binary(asciiValueToWrite,dataType,&octetBinaryBuffer_,ADS_CMD_BUFFER_SIZE,&bytesToWrite);
   if(error){
-    adsUnlock();
     octetCmdBuf_printf(asciiResponseBuffer,"Error: %x", error);
     asynPrint(pasynUserSelf, ASYN_TRACE_ERROR, "%s:%s: ASCII to binary conversion failed with: %d.\n", driverName, functionName,error);
     return error;
@@ -2806,15 +2910,13 @@ int adsAsynPortDriver::octetAdsWriteByGroupOffset(uint16_t amsPort,uint32_t grou
     bytesToWrite=dataSize;
   }
 
-  error = AdsSyncWriteReqEx(adsPort_, &amsServer, group, offset, bytesToWrite, &octetBinaryBuffer_);
+  error = AdsSyncWriteReqEx(amsClientPort, &amsServer, group, offset, bytesToWrite, &octetBinaryBuffer_);
 
   if (error) {
     asynPrint(pasynUserSelf, ASYN_TRACE_ERROR, "%s:%s: ADS write failed with: %s (0x%x).\n", driverName, functionName,adsErrorToString(error),error);
-    adsUnlock();
     return error;
   }
 
-  adsUnlock();
   return 0;
 }
 
@@ -2830,19 +2932,24 @@ asynStatus adsAsynPortDriver::readInt32(asynUser *pasynUser, epicsInt32 *value)
   const char* functionName = "readInt32";
   asynPrint(pasynUser, ASYN_TRACE_FLOW, "%s:%s:\n", driverName, functionName);
 
-  int paramIndex = pasynUser->reason;
-  if (!pAdsParamArray_[paramIndex]) {
-    asynPrint(pasynUser, ASYN_TRACE_ERROR, "%s:%s: pAdsParamArray NULL\n", driverName, functionName);
-    return asynError;
+  long amsClientPort = 0;
+  AdsClientPortGuard adsClientPortGuard(*this, amsClientPort);
+  if (isInvalidPortNumber(amsClientPort))
+  {
+    throw std::runtime_error(string_format(
+        "%s:%s: failed to open ads client port for this thread.\n", 
+        driverName, __func__));
   }
-  adsParamInfo *paramInfo = pAdsParamArray_[paramIndex];
+
+  int paramIndex = pasynUser->reason;
+  auto paramInfo = &adsParamArray_[paramIndex];
 
   // adsReadParam(..., 1) issues AdsSyncReadReqEx2, then calls
   // adsUpdateParameterLock -> setIntegerParam/setDoubleParam under the asyn
   // port lock.  The base-class readInt32 then retrieves the value from the
   // parameter table.  This completely bypasses the bulk poll thread.
   long errorCode = 0;
-  if (adsReadParam(paramInfo, &errorCode, 1) != asynSuccess) {
+  if (adsReadParam(amsClientPort,paramInfo, &errorCode, 1) != asynSuccess) {
     asynPrint(pasynUser, ASYN_TRACE_ERROR, "%s:%s: adsReadParam failed for %s (0x%lx)\n",
               driverName, functionName, paramInfo->drvInfo, errorCode);
     return setAlarmParam(paramInfo, READ_ALARM, INVALID_ALARM);
@@ -2865,15 +2972,20 @@ asynStatus adsAsynPortDriver::readFloat64(asynUser *pasynUser, epicsFloat64 *val
   const char* functionName = "readFloat64";
   asynPrint(pasynUser, ASYN_TRACE_FLOW, "%s:%s:\n", driverName, functionName);
 
-  int paramIndex = pasynUser->reason;
-  if (!pAdsParamArray_[paramIndex]) {
-    asynPrint(pasynUser, ASYN_TRACE_ERROR, "%s:%s: pAdsParamArray NULL\n", driverName, functionName);
-    return asynError;
+  long amsClientPort = 0;
+  AdsClientPortGuard adsClientPortGuard(*this, amsClientPort);
+  if (isInvalidPortNumber(amsClientPort))
+  {
+    throw std::runtime_error(string_format(
+        "%s:%s: failed to open ads client port for this thread.\n", 
+        driverName, __func__));
   }
-  adsParamInfo *paramInfo = pAdsParamArray_[paramIndex];
+
+  int paramIndex = pasynUser->reason;
+  auto paramInfo = &adsParamArray_[paramIndex];
 
   long errorCode = 0;
-  if (adsReadParam(paramInfo, &errorCode, 1) != asynSuccess) {
+  if (adsReadParam(amsClientPort,paramInfo, &errorCode, 1) != asynSuccess) {
     asynPrint(pasynUser, ASYN_TRACE_ERROR, "%s:%s: adsReadParam failed for %s (0x%lx)\n",
               driverName, functionName, paramInfo->drvInfo, errorCode);
     return setAlarmParam(paramInfo, READ_ALARM, INVALID_ALARM);
@@ -2895,21 +3007,29 @@ asynStatus adsAsynPortDriver::writeInt32(asynUser *pasynUser, epicsInt32 value)
 {
   const char* functionName = "writeInt32";
   asynPrint(pasynUser, ASYN_TRACE_FLOW, "%s:%s:\n", driverName, functionName);
-  adsParamInfo *paramInfo;
+
+  long amsClientPort = 0;
+  AdsClientPortGuard adsClientPortGuard(*this, amsClientPort);
+  if (isInvalidPortNumber(amsClientPort))
+  {
+    throw std::runtime_error(string_format(
+        "%s:%s: failed to open ads client port for this thread.\n", 
+        driverName, __func__));
+  }
+
   int paramIndex = pasynUser->reason;
 
-  if(!pAdsParamArray_[paramIndex]){
-    asynPrint(pasynUser, ASYN_TRACE_ERROR, "%s:%s: pAdsParamArray NULL\n", driverName, functionName);
+  if(paramIndex >= getAdsParamCount()){
+    asynPrint(pasynUser, ASYN_TRACE_ERROR, "%s:%s: param index invalid. Greater than param count.\n", driverName, functionName);
     pasynUser->alarmStatus=WRITE_ALARM;
-    callParamCallbacks();
     return asynError;
   }
 
-  paramInfo=pAdsParamArray_[paramIndex];
+  auto paramInfo=&adsParamArray_[paramIndex];
 
   //Special case. Check if write ams port state
   if(paramInfo->dataSource==ADS_DATASOURCE_AMS_STATE){
-    if(adsWriteState(paramInfo->amsPort,(uint16_t)value)!=asynSuccess){
+    if(adsWriteState(amsClientPort,paramInfo->amsPort,(uint16_t)value)!=asynSuccess){
       return setAlarmParam(paramInfo,WRITE_ALARM,INVALID_ALARM);
     }
     // Write OK -> reset write alarm
@@ -2991,14 +3111,12 @@ asynStatus adsAsynPortDriver::writeInt32(asynUser *pasynUser, epicsInt32 value)
   if(maxBytesToWrite!=paramInfo->plcSize || maxBytesToWrite==0){
     asynPrint(pasynUser, ASYN_TRACE_ERROR, "%s:%s: Data types size missmatch (%s and %d bytes). Write canceled.\n", driverName, functionName,adsTypeToString(paramInfo->plcDataType),maxBytesToWrite);
     setAlarmParam(paramInfo,WRITE_ALARM,INVALID_ALARM);
-    callParamCallbacks();
     return asynError;
   }
 
   //Do the write
-  if(adsWriteParam(paramInfo,(const void *)buffer,maxBytesToWrite)!=asynSuccess){
+  if(adsWriteParam(amsClientPort,paramInfo,(const void *)buffer,maxBytesToWrite)!=asynSuccess){
     setAlarmParam(paramInfo,WRITE_ALARM,INVALID_ALARM);
-    callParamCallbacks();
     return asynError;
   }
   //Only reset if write alarm
@@ -3021,15 +3139,24 @@ asynStatus adsAsynPortDriver::readInt64(asynUser *pasynUser, epicsInt64 *value)
     const char* functionName = "readInt64";
     asynPrint(pasynUser, ASYN_TRACE_FLOW, "%s:%s:\n", driverName, functionName);
 
+  long amsClientPort = 0;
+  AdsClientPortGuard adsClientPortGuard(*this, amsClientPort);
+  if (isInvalidPortNumber(amsClientPort))
+  {
+    throw std::runtime_error(string_format(
+        "%s:%s: failed to open ads client port for this thread.\n", 
+        driverName, __func__));
+  }
+
     int paramIndex = pasynUser->reason;
-    if (!pAdsParamArray_[paramIndex]) {
-        asynPrint(pasynUser, ASYN_TRACE_ERROR, "%s:%s: pAdsParamArray NULL\n", driverName, functionName);
+    if (paramIndex >= getAdsParamCount()) {
+        asynPrint(pasynUser, ASYN_TRACE_ERROR, "%s:%s: param index invalid. Greater than registered param count.\n", driverName, functionName);
         return asynError;
     }
-    adsParamInfo *paramInfo = pAdsParamArray_[paramIndex];
+    auto paramInfo = &adsParamArray_[paramIndex];
 
     long errorCode = 0;
-    if (adsReadParam(paramInfo, &errorCode, 1) != asynSuccess) {
+    if (adsReadParam(amsClientPort, paramInfo, &errorCode, 1) != asynSuccess) {
         asynPrint(pasynUser, ASYN_TRACE_ERROR, "%s:%s: adsReadParam failed for %s (0x%lx)\n",
                   driverName, functionName, paramInfo->drvInfo, errorCode);
         return setAlarmParam(paramInfo, READ_ALARM, INVALID_ALARM);
@@ -3044,21 +3171,26 @@ asynStatus adsAsynPortDriver::writeInt64(asynUser *pasynUser, epicsInt64 value)
 {
     const char* functionName = "writeInt64";
     asynPrint(pasynUser, ASYN_TRACE_FLOW, "%s:%s:\n", driverName, functionName);
-    adsParamInfo *paramInfo;
-    int paramIndex = pasynUser->reason;
 
-    if (!pAdsParamArray_[paramIndex]) {
-        asynPrint(pasynUser, ASYN_TRACE_ERROR, "%s:%s: pAdsParamArray NULL\n", driverName, functionName);
-        pasynUser->alarmStatus = WRITE_ALARM;
-        callParamCallbacks();
+  long amsClientPort = 0;
+  AdsClientPortGuard adsClientPortGuard(*this, amsClientPort);
+  if (isInvalidPortNumber(amsClientPort))
+  {
+    throw std::runtime_error(string_format(
+        "%s:%s: failed to open ads client port for this thread.\n", 
+        driverName, __func__));
+  }
+
+    int paramIndex = pasynUser->reason;
+    if (paramIndex >= getAdsParamCount()) {
+        asynPrint(pasynUser, ASYN_TRACE_ERROR, "%s:%s: param index invalid. Greater than registered param count.\n", driverName, functionName);
         return asynError;
     }
-
-    paramInfo = pAdsParamArray_[paramIndex];
+    auto paramInfo = &adsParamArray_[paramIndex];
 
     // Special case: AMS port state
     if (paramInfo->dataSource == ADS_DATASOURCE_AMS_STATE) {
-        if (adsWriteState(paramInfo->amsPort, (uint16_t)value) != asynSuccess) {
+        if (adsWriteState(amsClientPort,paramInfo->amsPort, (uint16_t)value) != asynSuccess) {
             return setAlarmParam(paramInfo, WRITE_ALARM, INVALID_ALARM);
         }
         if (paramInfo->alarmStatus == WRITE_ALARM) {
@@ -3102,14 +3234,12 @@ asynStatus adsAsynPortDriver::writeInt64(asynUser *pasynUser, epicsInt64 value)
         asynPrint(pasynUser, ASYN_TRACE_ERROR, "%s:%s: Data types size mismatch (%s and %d bytes). Write canceled.\n",
             driverName, functionName, adsTypeToString(paramInfo->plcDataType), maxBytesToWrite);
         setAlarmParam(paramInfo, WRITE_ALARM, INVALID_ALARM);
-        callParamCallbacks();
         return asynError;
     }
 
     // Write the value
-    if (adsWriteParam(paramInfo, buffer, maxBytesToWrite) != asynSuccess) {
+    if (adsWriteParam(amsClientPort, paramInfo, buffer, maxBytesToWrite) != asynSuccess) {
         setAlarmParam(paramInfo, WRITE_ALARM, INVALID_ALARM);
-        callParamCallbacks();
         return asynError;
     }
     if (paramInfo->alarmStatus == WRITE_ALARM) {
@@ -3132,21 +3262,25 @@ asynStatus adsAsynPortDriver::writeFloat64(asynUser *pasynUser, epicsFloat64 val
   const char* functionName = "writeFloat64";
   asynPrint(pasynUser, ASYN_TRACE_FLOW, "%s:%s:\n", driverName, functionName);
 
-   adsParamInfo *paramInfo;
-  int paramIndex = pasynUser->reason;
-
-  if(!pAdsParamArray_[paramIndex]){
-    asynPrint(pasynUser, ASYN_TRACE_ERROR, "%s:%s: pAdsParamArray NULL\n", driverName, functionName);
-    pasynUser->alarmStatus=WRITE_ALARM;
-    pasynUser->alarmSeverity=INVALID_ALARM;
-    callParamCallbacks();
-    return asynError;
+  long amsClientPort = 0;
+  AdsClientPortGuard adsClientPortGuard(*this, amsClientPort);
+  if (isInvalidPortNumber(amsClientPort))
+  {
+    throw std::runtime_error(string_format(
+        "%s:%s: failed to open ads client port for this thread.\n", 
+        driverName, __func__));
   }
-  paramInfo=pAdsParamArray_[paramIndex];
+
+  int paramIndex = pasynUser->reason;
+  if (paramIndex >= getAdsParamCount()) {
+      asynPrint(pasynUser, ASYN_TRACE_ERROR, "%s:%s: param index invalid. Greater than registered param count.\n", driverName, functionName);
+      return asynError;
+  }
+  auto paramInfo = &adsParamArray_[paramIndex];
 
   //Special case. Check if write ams port state
   if(paramInfo->dataSource==ADS_DATASOURCE_AMS_STATE){
-    if(adsWriteState(paramInfo->amsPort,(uint16_t)value)!=asynSuccess){
+    if(adsWriteState(amsClientPort,paramInfo->amsPort,(uint16_t)value)!=asynSuccess){
       return setAlarmParam(paramInfo,WRITE_ALARM,INVALID_ALARM);
     }
     // Write OK -> reset write alarm
@@ -3240,14 +3374,12 @@ asynStatus adsAsynPortDriver::writeFloat64(asynUser *pasynUser, epicsFloat64 val
   if(maxBytesToWrite!=paramInfo->plcSize || maxBytesToWrite==0){
     asynPrint(pasynUser, ASYN_TRACE_ERROR, "%s:%s: Data types size mismatch (%s and %d bytes). Write canceled.\n", driverName, functionName,adsTypeToString(paramInfo->plcDataType),maxBytesToWrite);
     setAlarmParam(paramInfo,WRITE_ALARM,INVALID_ALARM);
-    callParamCallbacks();
     return asynError;
   }
 
   //Do the write
-  if(adsWriteParam(paramInfo,(const void *)buffer,maxBytesToWrite)!=asynSuccess){
+  if(adsWriteParam(amsClientPort,paramInfo,(const void *)buffer,maxBytesToWrite)!=asynSuccess){
     setAlarmParam(paramInfo,WRITE_ALARM,INVALID_ALARM);
-    callParamCallbacks();
     return asynError;
   }
 
@@ -3270,21 +3402,17 @@ asynStatus adsAsynPortDriver::writeFloat64(asynUser *pasynUser, epicsFloat64 val
  *
  * \return asynSuccess or asynError.
  */
-asynStatus adsAsynPortDriver::adsGenericArrayRead(asynUser *pasynUser,long allowedType,void *epicsDataBuffer,size_t nEpicsBufferBytes,size_t *nBytesRead)
+asynStatus adsAsynPortDriver::adsGenericArrayRead(uint16_t amsClientPort,asynUser *pasynUser,long allowedType,void *epicsDataBuffer,size_t nEpicsBufferBytes,size_t *nBytesRead)
 {
   const char* functionName = "adsGenericArrayRead";
   asynPrint(pasynUser, ASYN_TRACE_FLOW, "%s:%s:\n", driverName, functionName);
 
-  int paramIndex=pasynUser->reason;
-
-  if(!pAdsParamArray_[paramIndex] || paramIndex>=paramTableSize_){
-    asynPrint(pasynUser, ASYN_TRACE_ERROR, "%s:%s: pAdsParamArray NULL or index (pasynUser->reason) our of range\n", driverName, functionName);
-    pasynUser->alarmStatus=READ_ALARM;
-    pasynUser->alarmSeverity=INVALID_ALARM;
-    return asynError;
+  int paramIndex = pasynUser->reason;
+  if (paramIndex >= getAdsParamCount()) {
+      asynPrint(pasynUser, ASYN_TRACE_ERROR, "%s:%s: param index invalid. Greater than registered param count.\n", driverName, functionName);
+      return asynError;
   }
-
-  adsParamInfo *paramInfo=pAdsParamArray_[paramIndex];
+  auto paramInfo = &adsParamArray_[paramIndex];
 
   //Only support same datatype as in PLC
   // Allow LWORD/ULINT as signed INT64
@@ -3330,21 +3458,17 @@ asynStatus adsAsynPortDriver::adsGenericArrayRead(asynUser *pasynUser,long allow
  *
  * \return asynSuccess or asynError.
  */
-asynStatus adsAsynPortDriver::adsGenericArrayWrite(asynUser *pasynUser,long allowedType,const void *data,size_t nEpicsBufferBytes)
+asynStatus adsAsynPortDriver::adsGenericArrayWrite(uint16_t amsClientPort,asynUser *pasynUser,long allowedType,const void *data,size_t nEpicsBufferBytes)
 {
   const char* functionName = "adsGenericArrayWrite";
   asynPrint(pasynUser, ASYN_TRACE_FLOW, "%s:%s:\n", driverName, functionName);
 
-  int paramIndex=pasynUser->reason;
-
-  if(!pAdsParamArray_[paramIndex] || paramIndex>=paramTableSize_){
-    asynPrint(pasynUser, ASYN_TRACE_ERROR, "%s:%s: pAdsParamArray NULL or index (pasynUser->reason) our of range\n", driverName, functionName);
-    pasynUser->alarmStatus=WRITE_ALARM;
-    pasynUser->alarmSeverity=INVALID_ALARM;
-    return asynError;
+  int paramIndex = pasynUser->reason;
+  if (paramIndex >= getAdsParamCount()) {
+      asynPrint(pasynUser, ASYN_TRACE_ERROR, "%s:%s: param index invalid. Greater than registered param count.\n", driverName, functionName);
+      return asynError;
   }
-
-  adsParamInfo *paramInfo=pAdsParamArray_[paramIndex];
+  auto paramInfo = &adsParamArray_[paramIndex];
 
   //Only support same datatype as in PLC
   // Allow LWORD/ULINT as signed INT64
@@ -3363,7 +3487,7 @@ asynStatus adsAsynPortDriver::adsGenericArrayWrite(asynUser *pasynUser,long allo
   }
 
   //Write to ADS
-  asynStatus stat=adsWriteParam(paramInfo,data,bytesToWrite);
+  asynStatus stat=adsWriteParam(amsClientPort,paramInfo,data,bytesToWrite);
   if(stat!=asynSuccess){
     setAlarmParam(paramInfo,WRITE_ALARM,INVALID_ALARM);
     return asynError;
@@ -3396,24 +3520,34 @@ asynStatus adsAsynPortDriver::readInt8Array(asynUser *pasynUser,epicsInt8 *value
   const char* functionName = "readInt8Array";
   asynPrint(pasynUser, ASYN_TRACE_FLOW, "%s:%s:\n", driverName, functionName);
 
-  if(!pAdsParamArray_[pasynUser->reason]){
-    asynPrint(pasynUser, ASYN_TRACE_ERROR, "%s:%s: pAdsParamArray NULL\n", driverName, functionName);
-    return asynError;
+  long amsClientPort = 0;
+  AdsClientPortGuard adsClientPortGuard(*this, amsClientPort);
+  if (isInvalidPortNumber(amsClientPort))
+  {
+    throw std::runtime_error(string_format(
+        "%s:%s: failed to open ads client port for this thread.\n", 
+        driverName, __func__));
   }
+
+  int paramIndex = pasynUser->reason;
+  if (paramIndex >= getAdsParamCount()) {
+      asynPrint(pasynUser, ASYN_TRACE_ERROR, "%s:%s: param index invalid. Greater than registered param count.\n", driverName, functionName);
+      return asynError;
+  }
+  auto paramInfo = &adsParamArray_[paramIndex];
 
   long allowedType=ADST_INT8;
 
   //Also allow string and bool array as int8array (special case)
-  if(pAdsParamArray_[pasynUser->reason]->plcDataType==ADST_STRING){
+  if(paramInfo->plcDataType==ADST_STRING){
     allowedType=ADST_STRING;
   }
-  else if(pAdsParamArray_[pasynUser->reason]->plcDataType==ADST_BIT){
+  else if(paramInfo->plcDataType==ADST_BIT){
     allowedType=ADST_BIT;
   }
 
-
   size_t nBytesRead=0;
-  asynStatus stat=adsGenericArrayRead(pasynUser, allowedType,(void *)value,nElements*sizeof(epicsInt8),&nBytesRead);
+  asynStatus stat=adsGenericArrayRead(amsClientPort,pasynUser, allowedType,(void *)value,nElements*sizeof(epicsInt8),&nBytesRead);
   if(stat!=asynSuccess){
     return asynError;
   }
@@ -3434,18 +3568,33 @@ asynStatus adsAsynPortDriver::writeInt8Array(asynUser *pasynUser, epicsInt8 *val
   const char* functionName = "writeInt8Array";
   asynPrint(pasynUser, ASYN_TRACE_FLOW, "%s:%s:\n", driverName, functionName);
 
+  long amsClientPort = 0;
+  AdsClientPortGuard adsClientPortGuard(*this, amsClientPort);
+  if (isInvalidPortNumber(amsClientPort))
+  {
+    throw std::runtime_error(string_format(
+        "%s:%s: failed to open ads client port for this thread.\n", 
+        driverName, __func__));
+  }
+
+  int paramIndex = pasynUser->reason;
+  if (paramIndex >= getAdsParamCount()) {
+      asynPrint(pasynUser, ASYN_TRACE_ERROR, "%s:%s: param index invalid. Greater than registered param count.\n", driverName, functionName);
+      return asynError;
+  }
+  auto paramInfo = &adsParamArray_[paramIndex];
 
   long allowedType=ADST_INT8;
 
   //Also allow string and bool array as int8array (special case)
-  if(pAdsParamArray_[pasynUser->reason]->plcDataType==ADST_STRING){
+  if(paramInfo->plcDataType==ADST_STRING){
     allowedType=ADST_STRING;
   }
-  else if(pAdsParamArray_[pasynUser->reason]->plcDataType==ADST_BIT){
+  else if(paramInfo->plcDataType==ADST_BIT){
     allowedType=ADST_BIT;
   }
 
-  return adsGenericArrayWrite(pasynUser,allowedType,(const void *)value,nElements*sizeof(epicsInt8));
+  return adsGenericArrayWrite(amsClientPort,pasynUser,allowedType,(const void *)value,nElements*sizeof(epicsInt8));
 }
 
 /** Overrides asynPortDriver::readInt16Array.
@@ -3462,10 +3611,19 @@ asynStatus adsAsynPortDriver::readInt16Array(asynUser *pasynUser,epicsInt16 *val
   const char* functionName = "readInt16Array";
   asynPrint(pasynUser, ASYN_TRACE_FLOW, "%s:%s:\n", driverName, functionName);
 
+  long amsClientPort = 0;
+  AdsClientPortGuard adsClientPortGuard(*this, amsClientPort);
+  if (isInvalidPortNumber(amsClientPort))
+  {
+    throw std::runtime_error(string_format(
+        "%s:%s: failed to open ads client port for this thread.\n", 
+        driverName, __func__));
+  }
+
   long allowedType=ADST_INT16;
 
   size_t nBytesRead=0;
-  asynStatus stat=adsGenericArrayRead(pasynUser, allowedType,(void *)value,nElements*sizeof(epicsInt16),&nBytesRead);
+  asynStatus stat=adsGenericArrayRead(amsClientPort,pasynUser, allowedType,(void *)value,nElements*sizeof(epicsInt16),&nBytesRead);
   if(stat!=asynSuccess){
     return asynError;
   }
@@ -3486,9 +3644,18 @@ asynStatus adsAsynPortDriver::writeInt16Array(asynUser *pasynUser, epicsInt16 *v
   const char* functionName = "writeInt16Array";
   asynPrint(pasynUser, ASYN_TRACE_FLOW, "%s:%s:\n", driverName, functionName);
 
+  long amsClientPort = 0;
+  AdsClientPortGuard adsClientPortGuard(*this, amsClientPort);
+  if (isInvalidPortNumber(amsClientPort))
+  {
+    throw std::runtime_error(string_format(
+        "%s:%s: failed to open ads client port for this thread.\n", 
+        driverName, __func__));
+  }
+
   long allowedType=ADST_INT16;
 
-  return adsGenericArrayWrite(pasynUser,allowedType,(const void *)value,nElements*sizeof(epicsInt16));
+  return adsGenericArrayWrite(amsClientPort,pasynUser,allowedType,(const void *)value,nElements*sizeof(epicsInt16));
 }
 
 /** Overrides asynPortDriver::readInt32Array.
@@ -3505,10 +3672,19 @@ asynStatus adsAsynPortDriver::readInt32Array(asynUser *pasynUser,epicsInt32 *val
   const char* functionName = "readInt32Array";
   asynPrint(pasynUser, ASYN_TRACE_FLOW, "%s:%s:\n", driverName, functionName);
 
+  long amsClientPort = 0;
+  AdsClientPortGuard adsClientPortGuard(*this, amsClientPort);
+  if (isInvalidPortNumber(amsClientPort))
+  {
+    throw std::runtime_error(string_format(
+        "%s:%s: failed to open ads client port for this thread.\n", 
+        driverName, __func__));
+  }
+
   long allowedType=ADST_INT32;
 
   size_t nBytesRead=0;
-  asynStatus stat=adsGenericArrayRead(pasynUser, allowedType,(void *)value,nElements*sizeof(epicsInt32),&nBytesRead);
+  asynStatus stat=adsGenericArrayRead(amsClientPort,pasynUser, allowedType,(void *)value,nElements*sizeof(epicsInt32),&nBytesRead);
   if(stat!=asynSuccess){
     return asynError;
   }
@@ -3530,9 +3706,18 @@ asynStatus adsAsynPortDriver::writeInt32Array(asynUser *pasynUser, epicsInt32 *v
   const char* functionName = "writeInt32Array";
   asynPrint(pasynUser, ASYN_TRACE_FLOW, "%s:%s:\n", driverName, functionName);
 
+  long amsClientPort = 0;
+  AdsClientPortGuard adsClientPortGuard(*this, amsClientPort);
+  if (isInvalidPortNumber(amsClientPort))
+  {
+    throw std::runtime_error(string_format(
+        "%s:%s: failed to open ads client port for this thread.\n", 
+        driverName, __func__));
+  }
+
   long allowedType=ADST_INT32;
 
-  return adsGenericArrayWrite(pasynUser,allowedType,(const void *)value,nElements*sizeof(epicsInt32));
+  return adsGenericArrayWrite(amsClientPort,pasynUser,allowedType,(const void *)value,nElements*sizeof(epicsInt32));
 }
 
 /** Overrides asynPortDriver::readFloat32Array.
@@ -3549,10 +3734,19 @@ asynStatus adsAsynPortDriver::readFloat32Array(asynUser *pasynUser,epicsFloat32 
   const char* functionName = "readFloat32Array";
   asynPrint(pasynUser, ASYN_TRACE_FLOW, "%s:%s:\n", driverName, functionName);
 
+  long amsClientPort = 0;
+  AdsClientPortGuard adsClientPortGuard(*this, amsClientPort);
+  if (isInvalidPortNumber(amsClientPort))
+  {
+    throw std::runtime_error(string_format(
+        "%s:%s: failed to open ads client port for this thread.\n", 
+        driverName, __func__));
+  }
+
   long allowedType=ADST_REAL32;
 
   size_t nBytesRead=0;
-  asynStatus stat=adsGenericArrayRead(pasynUser, allowedType,(void *)value,nElements*sizeof(epicsFloat32),&nBytesRead);
+  asynStatus stat=adsGenericArrayRead(amsClientPort,pasynUser, allowedType,(void *)value,nElements*sizeof(epicsFloat32),&nBytesRead);
   if(stat!=asynSuccess){
     return asynError;
   }
@@ -3573,8 +3767,17 @@ asynStatus adsAsynPortDriver::writeFloat32Array(asynUser *pasynUser,epicsFloat32
   const char* functionName = "writeFloat32Array";
   asynPrint(pasynUser, ASYN_TRACE_FLOW, "%s:%s:\n", driverName, functionName);
 
+  long amsClientPort = 0;
+  AdsClientPortGuard adsClientPortGuard(*this, amsClientPort);
+  if (isInvalidPortNumber(amsClientPort))
+  {
+    throw std::runtime_error(string_format(
+        "%s:%s: failed to open ads client port for this thread.\n", 
+        driverName, __func__));
+  }
+
   long allowedType=ADST_REAL32;
-  return adsGenericArrayWrite(pasynUser,allowedType,(const void *)value,nElements*sizeof(epicsFloat32));
+  return adsGenericArrayWrite(amsClientPort,pasynUser,allowedType,(const void *)value,nElements*sizeof(epicsFloat32));
 }
 
 
@@ -3583,10 +3786,19 @@ asynStatus adsAsynPortDriver::readInt64Array(asynUser *pasynUser, epicsInt64 *va
     const char* functionName = "readInt64Array";
     asynPrint(pasynUser, ASYN_TRACE_FLOW, "%s:%s:\n", driverName, functionName);
 
+  long amsClientPort = 0;
+  AdsClientPortGuard adsClientPortGuard(*this, amsClientPort);
+  if (isInvalidPortNumber(amsClientPort))
+  {
+    throw std::runtime_error(string_format(
+        "%s:%s: failed to open ads client port for this thread.\n", 
+        driverName, __func__));
+  }
+
     long allowedType = ADST_INT64;
 
     size_t nBytesRead = 0;
-    asynStatus stat = adsGenericArrayRead(pasynUser, allowedType, (void *)value, nElements * sizeof(epicsInt64), &nBytesRead);
+    asynStatus stat = adsGenericArrayRead(amsClientPort,pasynUser, allowedType, (void *)value, nElements * sizeof(epicsInt64), &nBytesRead);
     if (stat != asynSuccess) {
         return asynError;
     }
@@ -3599,9 +3811,18 @@ asynStatus adsAsynPortDriver::writeInt64Array(asynUser *pasynUser, epicsInt64 *v
     const char* functionName = "writeInt64Array";
     asynPrint(pasynUser, ASYN_TRACE_FLOW, "%s:%s:\n", driverName, functionName);
 
+  long amsClientPort = 0;
+  AdsClientPortGuard adsClientPortGuard(*this, amsClientPort);
+  if (isInvalidPortNumber(amsClientPort))
+  {
+    throw std::runtime_error(string_format(
+        "%s:%s: failed to open ads client port for this thread.\n", 
+        driverName, __func__));
+  }
+
     long allowedType = ADST_INT64;
 
-    return adsGenericArrayWrite(pasynUser, allowedType, (const void *)value, nElements * sizeof(epicsInt64));
+    return adsGenericArrayWrite(amsClientPort,pasynUser, allowedType, (const void *)value, nElements * sizeof(epicsInt64));
 }
 
 /** Overrides asynPortDriver::readFloat64Array.
@@ -3618,10 +3839,19 @@ asynStatus adsAsynPortDriver::readFloat64Array(asynUser *pasynUser,epicsFloat64 
   const char* functionName = "readFloat64Array";
   asynPrint(pasynUser, ASYN_TRACE_FLOW, "%s:%s:\n", driverName, functionName);
 
+  long amsClientPort = 0;
+  AdsClientPortGuard adsClientPortGuard(*this, amsClientPort);
+  if (isInvalidPortNumber(amsClientPort))
+  {
+    throw std::runtime_error(string_format(
+        "%s:%s: failed to open ads client port for this thread.\n", 
+        driverName, __func__));
+  }
+
   long allowedType=ADST_REAL64;
 
   size_t nBytesRead=0;
-  asynStatus stat=adsGenericArrayRead(pasynUser, allowedType,(void *)value,nElements*sizeof(epicsFloat64),&nBytesRead);
+  asynStatus stat=adsGenericArrayRead(amsClientPort,pasynUser, allowedType,(void *)value,nElements*sizeof(epicsFloat64),&nBytesRead);
   if(stat!=asynSuccess){
     return asynError;
   }
@@ -3642,8 +3872,17 @@ asynStatus adsAsynPortDriver::writeFloat64Array(asynUser *pasynUser,epicsFloat64
   const char* functionName = "writeFloat64Array";
   asynPrint(pasynUser, ASYN_TRACE_FLOW, "%s:%s:\n", driverName, functionName);
 
+  long amsClientPort = 0;
+  AdsClientPortGuard adsClientPortGuard(*this, amsClientPort);
+  if (isInvalidPortNumber(amsClientPort))
+  {
+    throw std::runtime_error(string_format(
+        "%s:%s: failed to open ads client port for this thread.\n", 
+        driverName, __func__));
+  }
+
   long allowedType=ADST_REAL64;
-  return adsGenericArrayWrite(pasynUser,allowedType,(const void *)value,nElements*nElements*sizeof(epicsFloat64));
+  return adsGenericArrayWrite(amsClientPort,pasynUser,allowedType,(const void *)value,nElements*nElements*sizeof(epicsFloat64));
 }
 
 /** Returns pasynUserSelf for use in asynPrint().
@@ -3664,9 +3903,9 @@ asynUser *adsAsynPortDriver::getTraceAsynUser()
  *
  * \return asynSuccess or asynError.
  */
-asynStatus adsAsynPortDriver::adsGetSymHandleByName(adsParamInfo *paramInfo)
+asynStatus adsAsynPortDriver::adsGetSymHandleByName(uint16_t amsClientPort, adsParamInfo *paramInfo)
 {
-  return adsGetSymHandleByName(paramInfo,false);
+  return adsGetSymHandleByName(amsClientPort,paramInfo,false);
 }
 
 /** Get handle to symbolic plc variable.
@@ -3677,7 +3916,7 @@ asynStatus adsAsynPortDriver::adsGetSymHandleByName(adsParamInfo *paramInfo)
  *
  * \return asynSuccess or asynError.
  */
-asynStatus adsAsynPortDriver::adsGetSymHandleByName(adsParamInfo *paramInfo,bool blockErrorMsg)
+asynStatus adsAsynPortDriver::adsGetSymHandleByName(uint16_t amsClientPort,adsParamInfo *paramInfo,bool blockErrorMsg)
 {
   const char* functionName = "adsGetSymHandleByName";
   asynPrint(pasynUserSelf,ASYN_TRACE_FLOW, "%s:%s:\n", driverName, functionName);
@@ -3690,8 +3929,8 @@ asynStatus adsAsynPortDriver::adsGetSymHandleByName(adsParamInfo *paramInfo,bool
           "%s:%s: using amsPort=%u for symbol '%s'\n",
           driverName, functionName,
           paramInfo->amsPort, paramInfo->plcAdrStr);
-  adsLock();
-  const long handleStatus = AdsSyncReadWriteReqEx2(adsPort_,
+          
+  const long handleStatus = AdsSyncReadWriteReqEx2(amsClientPort,
                                                    &amsServer,
                                                    ADSIGRP_SYM_HNDBYNAME,
                                                    0,
@@ -3700,7 +3939,7 @@ asynStatus adsAsynPortDriver::adsGetSymHandleByName(adsParamInfo *paramInfo,bool
                                                    strlen(paramInfo->plcAdrStr),
                                                    paramInfo->plcAdrStr,
                                                    nullptr);
-  adsUnlock();
+                                                   
   if (handleStatus) {
     if(!blockErrorMsg){
       asynPrint(pasynUserSelf, ASYN_TRACE_ERROR, "%s:%s: Create handle for %s failed with: %s (0x%lx)\n", driverName, functionName,paramInfo->plcAdrStr,adsErrorToString(handleStatus),handleStatus);
@@ -3721,7 +3960,7 @@ asynStatus adsAsynPortDriver::adsGetSymHandleByName(adsParamInfo *paramInfo,bool
  *
  * \return asynSuccess or asynError.
  */
-asynStatus adsAsynPortDriver::adsAddSymbolsChangedCallback(amsPortInfo *port)
+asynStatus adsAsynPortDriver::adsAddSymbolsChangedCallback(uint16_t amsClientPort,amsPortInfo *port)
 {
   const char* functionName = "adsAddSymbolsChangedCallback";
   asynPrint(pasynUserSelf,ASYN_TRACE_FLOW, "%s:%s: Ams-port %u.\n", driverName, functionName,port->amsPort);
@@ -3736,8 +3975,8 @@ asynStatus adsAsynPortDriver::adsAddSymbolsChangedCallback(amsPortInfo *port)
   attrib.nCycleTime=(uint32_t)(defaultSampleTimeMS_*10000);
 
   uint32_t hNotify=0;
-  adsLock();
-  long addStatus = AdsSyncAddDeviceNotificationReqEx(adsPort_,
+
+  long addStatus = AdsSyncAddDeviceNotificationReqEx(amsClientPort,
                                                      &amsServer,
                                                      ADSIGRP_SYM_VERSION,
                                                      0,
@@ -3745,7 +3984,7 @@ asynStatus adsAsynPortDriver::adsAddSymbolsChangedCallback(amsPortInfo *port)
                                                      &adsSymbolsChangedCallback,
                                                      (uint32_t)port->amsPort,  //Use amsPort as hUser
                                                      &hNotify);
-  adsUnlock();
+                                                     
   if (addStatus){
     asynPrint(pasynUserSelf, ASYN_TRACE_ERROR, "%s:%s: Add device notification failed with: %s (0x%lx)\n", driverName, functionName,adsErrorToString(addStatus),addStatus);
     return asynError;
@@ -3765,7 +4004,7 @@ asynStatus adsAsynPortDriver::adsAddSymbolsChangedCallback(amsPortInfo *port)
  *
  * \return asynSuccess or asynError.
  */
-asynStatus adsAsynPortDriver::adsDelSymbolsChangedCallback(amsPortInfo *port)
+asynStatus adsAsynPortDriver::adsDelSymbolsChangedCallback(uint16_t amsClientPort,amsPortInfo *port)
 {
   const char* functionName = "adsDelSymbolsChangedCallback";
   asynPrint(pasynUserSelf,ASYN_TRACE_FLOW, "%s:%s:\n", driverName, functionName);
@@ -3773,9 +4012,8 @@ asynStatus adsAsynPortDriver::adsDelSymbolsChangedCallback(amsPortInfo *port)
   AmsAddr amsServer;
   amsServer={remoteNetId_,port->amsPort};
 
-  adsLock();
-  const long delStatus = AdsSyncDelDeviceNotificationReqEx(adsPort_, &amsServer,port->hCallbackNotify);
-  adsUnlock();
+  const long delStatus = AdsSyncDelDeviceNotificationReqEx(amsClientPort, &amsServer,port->hCallbackNotify);
+
   port->bCallbackNotifyValid=false;
   port->hCallbackNotify=-1;
 
@@ -3793,7 +4031,7 @@ asynStatus adsAsynPortDriver::adsDelSymbolsChangedCallback(amsPortInfo *port)
  *
  * \return asynSuccess or asynError.
  */
-asynStatus adsAsynPortDriver::adsAddDataCallback(adsParamInfo *paramInfo)
+asynStatus adsAsynPortDriver::adsAddDataCallback(uint16_t amsClientPort, adsParamInfo *paramInfo)
 {
   const char* functionName = "adsAddDataCallback";
   asynPrint(pasynUserSelf,ASYN_TRACE_FLOW, "%s:%s:\n", driverName, functionName);
@@ -3819,7 +4057,7 @@ asynStatus adsAsynPortDriver::adsAddDataCallback(adsParamInfo *paramInfo)
 
     // Read symbolic information if needed (to get paramInfo->plcSize)
     if(!paramInfo->plcAbsAdrValid){
-      asynStatus statusInfo=adsGetSymInfoByName(paramInfo);
+      asynStatus statusInfo=adsGetSymInfoByName(amsClientPort,paramInfo);
       if(statusInfo!=asynSuccess){
         asynPrint(pasynUserSelf, ASYN_TRACE_ERROR, "%s:%s: adsGetSymInfoByName failed.\n", driverName, functionName);
         return asynError;
@@ -3828,7 +4066,7 @@ asynStatus adsAsynPortDriver::adsAddDataCallback(adsParamInfo *paramInfo)
 
     // Get symbolic handle if needed
     if(!paramInfo->bSymbolicHandleValid){
-      asynStatus statusHandle=adsGetSymHandleByName(paramInfo);
+      asynStatus statusHandle=adsGetSymHandleByName(amsClientPort,paramInfo);
       if(statusHandle!=asynSuccess){
         asynPrint(pasynUserSelf, ASYN_TRACE_ERROR, "%s:%s: adsGetSymHandleByName failed.\n", driverName, functionName);
         return asynError;
@@ -3853,8 +4091,8 @@ asynStatus adsAsynPortDriver::adsAddDataCallback(adsParamInfo *paramInfo)
   attrib.nCycleTime=(uint32_t)(paramInfo->sampleTimeMS*10000);
 
   uint32_t hNotify=0;
-  adsLock();
-  long addStatus = AdsSyncAddDeviceNotificationReqEx(adsPort_,
+  
+  long addStatus = AdsSyncAddDeviceNotificationReqEx(amsClientPort,
                                                      &amsServer,
                                                      group,
                                                      offset,
@@ -3862,7 +4100,7 @@ asynStatus adsAsynPortDriver::adsAddDataCallback(adsParamInfo *paramInfo)
                                                      &adsDataCallback,
                                                      (uint32_t)paramInfo->paramIndex,
                                                      &hNotify);
-  adsUnlock();
+                                                     
   if (addStatus){
     asynPrint(pasynUserSelf, ASYN_TRACE_ERROR, "%s:%s: Add device notification failed with: %s (0x%lx)\n", driverName, functionName,adsErrorToString(addStatus),addStatus);
     return asynError;
@@ -3881,9 +4119,9 @@ asynStatus adsAsynPortDriver::adsAddDataCallback(adsParamInfo *paramInfo)
  *
  * \return asynSuccess or asynError.
  */
-asynStatus adsAsynPortDriver::adsDelDataCallback(adsParamInfo *paramInfo)
+asynStatus adsAsynPortDriver::adsDelDataCallback(uint16_t amsClientPort,adsParamInfo *paramInfo)
 {
-  return adsDelDataCallback(paramInfo,false);
+  return adsDelDataCallback(amsClientPort,paramInfo,false);
 }
 
 /** Unregister on-change callback for parameter (plc-variable).
@@ -3894,7 +4132,7 @@ asynStatus adsAsynPortDriver::adsDelDataCallback(adsParamInfo *paramInfo)
  *
  * \return asynSuccess or asynError.
  */
-asynStatus adsAsynPortDriver::adsDelDataCallback(adsParamInfo *paramInfo,bool blockErrorMsg)
+asynStatus adsAsynPortDriver::adsDelDataCallback(uint16_t amsClientPort,adsParamInfo *paramInfo,bool blockErrorMsg)
 {
   const char* functionName = "adsDelDataCallback";
   asynPrint(pasynUserSelf,ASYN_TRACE_FLOW, "%s:%s:\n", driverName, functionName);
@@ -3904,10 +4142,9 @@ asynStatus adsAsynPortDriver::adsDelDataCallback(adsParamInfo *paramInfo,bool bl
   AmsAddr amsServer;
   amsServer={remoteNetId_,paramInfo->amsPort};
 
-  adsLock();
-  const long delStatus = AdsSyncDelDeviceNotificationReqEx(adsPort_, &amsServer,paramInfo->hCallbackNotify);
+  const long delStatus = AdsSyncDelDeviceNotificationReqEx(amsClientPort, &amsServer,paramInfo->hCallbackNotify);
   paramInfo->hCallbackNotify=-1;
-  adsUnlock();
+  
   if (delStatus){
     if(!blockErrorMsg){
       asynPrint(pasynUserSelf, ASYN_TRACE_ERROR, "%s:%s: Delete device notification failed with: %s (0x%lx)\n", driverName, functionName,adsErrorToString(delStatus),delStatus);
@@ -3926,10 +4163,10 @@ asynStatus adsAsynPortDriver::adsDelDataCallback(adsParamInfo *paramInfo,bool bl
  *
  * \return asynSuccess or asynError.
  */
-asynStatus adsAsynPortDriver::adsGetSymInfoByName(uint16_t amsPort,const char *varName, adsSymbolEntry *info)
+asynStatus adsAsynPortDriver::adsGetSymInfoByName(uint16_t amsClientPort,uint16_t amsPort,const char *varName, adsSymbolEntry *info)
 {
   long errorCode=0;
-  return adsGetSymInfoByName(amsPort,varName,info,&errorCode);
+  return adsGetSymInfoByName(amsClientPort,amsPort,varName,info,&errorCode);
 }
 
 /** Get symbolic information for a plc variable.
@@ -3941,7 +4178,7 @@ asynStatus adsAsynPortDriver::adsGetSymInfoByName(uint16_t amsPort,const char *v
  *
  * \return asynSuccess or asynError.
  */
-asynStatus adsAsynPortDriver::adsGetSymInfoByName(uint16_t amsPort,const char *varName, adsSymbolEntry *info,long *errorCode)
+asynStatus adsAsynPortDriver::adsGetSymInfoByName(uint16_t amsClientPort,uint16_t amsPort,const char *varName, adsSymbolEntry *info,long *errorCode)
 {
   const char* functionName = "adsGetSymInfoByName";
   asynPrint(pasynUserSelf,ASYN_TRACE_FLOW, "%s:%s: Variable name: %s, amsPort: %d.\n", driverName, functionName,varName,(int)amsPort);
@@ -3955,8 +4192,8 @@ asynStatus adsAsynPortDriver::adsGetSymInfoByName(uint16_t amsPort,const char *v
   AmsAddr amsServer;
 
   amsServer={remoteNetId_,amsPort};
-  adsLock();
-  const long infoStatus = AdsSyncReadWriteReqEx2(adsPort_,
+  
+  const long infoStatus = AdsSyncReadWriteReqEx2(amsClientPort,
                                                  &amsServer,
                                                  ADSIGRP_SYM_INFOBYNAMEEX,
                                                  0,
@@ -3965,7 +4202,7 @@ asynStatus adsAsynPortDriver::adsGetSymInfoByName(uint16_t amsPort,const char *v
                                                  strlen(varName),
                                                  varName,
                                                  &bytesRead);
-  adsUnlock();
+                                                 
   *errorCode=infoStatus;
 
   if (infoStatus) {
@@ -3974,7 +4211,6 @@ asynStatus adsAsynPortDriver::adsGetSymInfoByName(uint16_t amsPort,const char *v
     /* Sigh.  It was up, now it's down.  Let's go home. */
     asynPrint(pasynUserSelf, ASYN_TRACE_ERROR, "%s:%s: Port error, giving up!\n", 
           driverName, functionName);
-    exit(1);
     }
     return asynError;
   }
@@ -4015,7 +4251,7 @@ asynStatus adsAsynPortDriver::adsGetSymInfoByName(uint16_t amsPort,const char *v
  *
  * \return asynSuccess or asynError.
  */
-asynStatus adsAsynPortDriver::adsGetSymInfoByName(adsParamInfo *paramInfo)
+asynStatus adsAsynPortDriver::adsGetSymInfoByName(uint16_t amsClientPort, adsParamInfo *paramInfo)
 {
   const char* functionName = "adsGetSymInfoByName";
   asynPrint(pasynUserSelf,ASYN_TRACE_FLOW, "%s:%s:\n", driverName, functionName);
@@ -4023,7 +4259,7 @@ asynStatus adsAsynPortDriver::adsGetSymInfoByName(adsParamInfo *paramInfo)
   adsSymbolEntry infoStruct;
   memset(&infoStruct,0,sizeof(infoStruct));
 
-  asynStatus stat=adsGetSymInfoByName(paramInfo->amsPort,paramInfo->plcAdrStr,&infoStruct);
+  asynStatus stat=adsGetSymInfoByName(amsClientPort,paramInfo->amsPort,paramInfo->plcAdrStr,&infoStruct);
   if (stat) {
     return asynError;
   }
@@ -4042,50 +4278,33 @@ asynStatus adsAsynPortDriver::adsGetSymInfoByName(adsParamInfo *paramInfo)
  *
  * \return asynSuccess or asynError.
  */
-asynStatus adsAsynPortDriver::adsConnect()
+asynStatus adsAsynPortDriver::adsConnect(uint16_t amsClientPort)
 {
   const char* functionName = "adsConnect";
   asynPrint(pasynUserSelf,ASYN_TRACE_FLOW, "%s:%s:\n", driverName, functionName);
 
-  adsDelRoute(1);
   // add local route to your ADS Master
   if(!routeAdded_){
-    asynStatus stat=adsAddRouteLock();
+    asynStatus stat=adsAddRoute();
 
     if (stat!=asynSuccess) {
       adsDelRoute(1);
-      if (adsPort_) {
-      adsLock();
-      AdsPortCloseEx(adsPort_);
-      adsPort_=0;
-      adsUnlock();
-      return asynError;
-      }
     }
   }
 
-  // open a new ADS port
-  adsLock();
-  if (!adsPort_)
-      adsPort_ = AdsPortOpenEx();
-  adsUnlock();
-  if (!adsPort_) {
-    asynPrint(pasynUserSelf, ASYN_TRACE_ERROR, "%s:%s:Open ADS port failed.\n", driverName, functionName);
-    return asynError;
-  }
   asynPrint(pasynUserSelf, ASYN_TRACE_FLOW, "%s:%s:Open ADS port = %ld.\n", driverName, functionName, adsPort_);
   // Update timeout
   uint32_t defaultTimeout=0;
-  adsLock();
-  long status=AdsSyncGetTimeoutEx(adsPort_,&defaultTimeout);
-  adsUnlock();
+  
+  long status=AdsSyncGetTimeoutEx(amsClientPort,&defaultTimeout);
+  
   if(status) {
     asynPrint(pasynUserSelf, ASYN_TRACE_ERROR, "%s:%s: AdsSyncGetTimeoutEx failed with: %s (0x%lx).\n", driverName, functionName,adsErrorToString(status),status);
     return asynError;
   }
-  adsLock();
-  status=AdsSyncSetTimeoutEx(adsPort_,(uint32_t)adsTimeoutMS_);
-  adsUnlock();
+  
+  status=AdsSyncSetTimeoutEx(amsClientPort,(uint32_t)adsTimeoutMS_);
+  
   if(status) {
     asynPrint(pasynUserSelf, ASYN_TRACE_ERROR, "%s:%s: AdsSyncSetTimeoutEx failed with: %s (0x%lx).\n", driverName, functionName,adsErrorToString(status),status);
     return asynError;
@@ -4100,7 +4319,7 @@ asynStatus adsAsynPortDriver::adsConnect()
  *
  * \return asynSuccess or asynError.
  */
-asynStatus adsAsynPortDriver::adsReadVersion(amsPortInfo *port)
+asynStatus adsAsynPortDriver::adsReadVersion(uint16_t amsClientPort,amsPortInfo *port)
 {
   const char* functionName = "adsReadVersion";
   asynPrint(pasynUserSelf,ASYN_TRACE_FLOW, "%s:%s: Ams-port %u\n", driverName, functionName,port->amsPort);
@@ -4110,9 +4329,8 @@ asynStatus adsAsynPortDriver::adsReadVersion(amsPortInfo *port)
   char devName[255];
   amsServer={remoteNetId_,port->amsPort};
 
-  adsLock();
-  long status=AdsSyncReadDeviceInfoReqEx(adsPort_,&amsServer,devName,&version);
-  adsUnlock();
+  long status=AdsSyncReadDeviceInfoReqEx(amsClientPort,&amsServer,devName,&version);
+  
   if(status) {
     asynPrint(pasynUserSelf, ASYN_TRACE_ERROR, "%s:%s: AdsSyncReadDeviceInfoReqEx failed with: %s (0x%lx).\n", driverName, functionName,adsErrorToString(status),status);
     return asynError;
@@ -4132,14 +4350,7 @@ asynStatus adsAsynPortDriver::adsDisconnect()
   const char* functionName = "adsDisconnect";
   asynPrint(pasynUserSelf,ASYN_TRACE_FLOW, "%s:%s: adsPort_=%ld\n", driverName, functionName, adsPort_);
 
-  adsLock();
-  const long closeStatus = AdsPortCloseEx(adsPort_);
-  adsPort_ = 0;
-  adsUnlock();
-  if (closeStatus) {
-    asynPrint(pasynUserSelf, ASYN_TRACE_ERROR, "%s:%s: Close ADS port failed with: %s (0x%lx)\n", driverName, functionName,adsErrorToString(closeStatus),closeStatus);
-    return asynError;
-  }
+  adsDelRoute(1);
 
   return asynSuccess;
 }
@@ -4150,9 +4361,9 @@ asynStatus adsAsynPortDriver::adsDisconnect()
  *
  * \return asynSuccess or asynError.
  */
-asynStatus adsAsynPortDriver::adsReleaseSymbolicHandle(adsParamInfo *paramInfo)
+asynStatus adsAsynPortDriver::adsReleaseSymbolicHandle(uint16_t amsClientPort,adsParamInfo *paramInfo)
 {
-  return adsReleaseSymbolicHandle(paramInfo, false);
+  return adsReleaseSymbolicHandle(amsClientPort,paramInfo, false);
 }
 
 /** Release handle to symbolic variable (in TwinCAT plc)
@@ -4163,7 +4374,7 @@ asynStatus adsAsynPortDriver::adsReleaseSymbolicHandle(adsParamInfo *paramInfo)
  *
  * \return asynSuccess or asynError.
  */
-asynStatus adsAsynPortDriver::adsReleaseSymbolicHandle(adsParamInfo *paramInfo, bool blockErrorMsg)
+asynStatus adsAsynPortDriver::adsReleaseSymbolicHandle(uint16_t amsClientPort,adsParamInfo *paramInfo, bool blockErrorMsg)
 {
   const char* functionName = "adsReleaseHandle";
   asynPrint(pasynUserSelf,ASYN_TRACE_FLOW, "%s:%s:\n", driverName, functionName);
@@ -4173,9 +4384,8 @@ asynStatus adsAsynPortDriver::adsReleaseSymbolicHandle(adsParamInfo *paramInfo, 
   AmsAddr amsServer;
   amsServer={remoteNetId_,paramInfo->amsPort};
 
-  adsLock();
-  const long releaseStatus = AdsSyncWriteReqEx(adsPort_, &amsServer, ADSIGRP_SYM_RELEASEHND, 0, sizeof(paramInfo->hSymbolicHandle), &paramInfo->hSymbolicHandle);
-  adsUnlock();
+  const long releaseStatus = AdsSyncWriteReqEx(amsClientPort, &amsServer, ADSIGRP_SYM_RELEASEHND, 0, sizeof(paramInfo->hSymbolicHandle), &paramInfo->hSymbolicHandle);
+
   paramInfo->hSymbolicHandle=-1;
   if (releaseStatus && !blockErrorMsg) {
     asynPrint(pasynUserSelf, ASYN_TRACE_ERROR, "%s:%s: Release of handle 0x%x failed with: %s (0x%lx)\n", driverName, functionName,paramInfo->hSymbolicHandle,adsErrorToString(releaseStatus),releaseStatus);
@@ -4193,7 +4403,7 @@ asynStatus adsAsynPortDriver::adsReleaseSymbolicHandle(adsParamInfo *paramInfo, 
  *
  * \return asynSuccess or asynError.
  */
-asynStatus adsAsynPortDriver::adsWriteParam(adsParamInfo *paramInfo,const void *binaryBuffer,uint32_t bytesToWrite)
+asynStatus adsAsynPortDriver::adsWriteParam(uint16_t amsClientPort,adsParamInfo *paramInfo,const void *binaryBuffer,uint32_t bytesToWrite)
 {
   const char* functionName = "adsWriteParam";
   asynPrint(pasynUserSelf,ASYN_TRACE_FLOW, "%s:%s:\n", driverName, functionName);
@@ -4222,7 +4432,7 @@ asynStatus adsAsynPortDriver::adsWriteParam(adsParamInfo *paramInfo,const void *
 
     // Read symbolic information if needed (to get paramInfo->plcSize)
     if(!paramInfo->plcAbsAdrValid){
-      asynStatus statusInfo=adsGetSymInfoByName(paramInfo);
+      asynStatus statusInfo=adsGetSymInfoByName(amsClientPort,paramInfo);
       if(statusInfo==asynError){
         asynPrint(pasynUserSelf, ASYN_TRACE_ERROR, "%s:%s: adsGetSymInfoByName failed.\n", driverName, functionName);
         return asynError;
@@ -4231,7 +4441,7 @@ asynStatus adsAsynPortDriver::adsWriteParam(adsParamInfo *paramInfo,const void *
 
     // Get symbolic handle if needed
     if(!paramInfo->bSymbolicHandleValid){
-      asynStatus statusHandle=adsGetSymHandleByName(paramInfo);
+      asynStatus statusHandle=adsGetSymHandleByName(amsClientPort,paramInfo);
       if(statusHandle!=asynSuccess){
         asynPrint(pasynUserSelf, ASYN_TRACE_ERROR, "%s:%s: adsGetSymHandleByName failed.\n", driverName, functionName);
         return asynError;
@@ -4241,14 +4451,14 @@ asynStatus adsAsynPortDriver::adsWriteParam(adsParamInfo *paramInfo,const void *
     group=ADSIGRP_SYM_VALBYHND;  //Access via symbolic handle stored in paramInfo->hSymbolicHandle
     offset=paramInfo->hSymbolicHandle;
   }
-  adsLock();
-  long writeStatus= AdsSyncWriteReqEx(adsPort_,
+  
+  long writeStatus= AdsSyncWriteReqEx(amsClientPort,
                                       &amsServer,
                                       group,
                                       offset,
                                       paramInfo->plcSize,
                                       binaryBuffer);
-  adsUnlock();
+                                      
   if (writeStatus) {
     asynPrint(pasynUserSelf, ASYN_TRACE_ERROR, "%s:%s: ADS write failed with: %s (0x%lx)\n", driverName, functionName,adsErrorToString(writeStatus),writeStatus);
     return asynError;
@@ -4268,10 +4478,10 @@ asynStatus adsAsynPortDriver::adsWriteParam(adsParamInfo *paramInfo,const void *
  *
  * \return asynSuccess or asynError.
  */
-asynStatus adsAsynPortDriver::adsReadParam(adsParamInfo *paramInfo)
+asynStatus adsAsynPortDriver::adsReadParam(uint16_t amsClientPort,adsParamInfo *paramInfo)
 {
   long notused=0;
-  return adsReadParam(paramInfo,&notused,1);
+  return adsReadParam(amsClientPort,paramInfo,&notused,1);
 }
 
 /** Read value of variable in TwinCAT.
@@ -4281,7 +4491,7 @@ asynStatus adsAsynPortDriver::adsReadParam(adsParamInfo *paramInfo)
  * \param[in] updateAsynPar Update asyn parameter.
  * \return asynSuccess or asynError.
  */
-asynStatus adsAsynPortDriver::adsReadParam(adsParamInfo *paramInfo,long *error,int updateAsynPar)
+asynStatus adsAsynPortDriver::adsReadParam(uint16_t amsClientPort,adsParamInfo *paramInfo,long *error,int updateAsynPar)
 {
   const char* functionName = "adsReadParam";
   asynPrint(pasynUserSelf,ASYN_TRACE_FLOW, "%s:%s:\n", driverName, functionName);
@@ -4306,7 +4516,7 @@ asynStatus adsAsynPortDriver::adsReadParam(adsParamInfo *paramInfo,long *error,i
 
     // Read symbolic information if needed (to get paramInfo->plcSize)
     if(!paramInfo->plcAbsAdrValid){
-      asynStatus statusInfo=adsGetSymInfoByName(paramInfo);
+      asynStatus statusInfo=adsGetSymInfoByName(amsClientPort,paramInfo);
       if(statusInfo==asynError){
         asynPrint(pasynUserSelf, ASYN_TRACE_ERROR, "%s:%s: adsGetSymInfoByName failed.\n", driverName, functionName);
         return asynError;
@@ -4315,7 +4525,7 @@ asynStatus adsAsynPortDriver::adsReadParam(adsParamInfo *paramInfo,long *error,i
 
     // Get symbolic handle if needed
     if(!paramInfo->bSymbolicHandleValid){
-      asynStatus statusHandle=adsGetSymHandleByName(paramInfo);
+      asynStatus statusHandle=adsGetSymHandleByName(amsClientPort,paramInfo);
       if(statusHandle!=asynSuccess){
         asynPrint(pasynUserSelf, ASYN_TRACE_ERROR, "%s:%s: adsGetSymHandleByName failed.\n", driverName, functionName);
         return asynError;
@@ -4328,15 +4538,15 @@ asynStatus adsAsynPortDriver::adsReadParam(adsParamInfo *paramInfo,long *error,i
 
   char *data=new char[paramInfo->plcSize];
   uint32_t bytesRead=0;
-  adsLock();
-  *error = AdsSyncReadReqEx2(adsPort_,
+  
+  *error = AdsSyncReadReqEx2(amsClientPort,
                                      &amsServer,
                                      group,
                                      offset,
                                      paramInfo->plcSize,
                                      (void *)data,
                                      &bytesRead);
-  adsUnlock();
+                                     
   if(*error){
     asynPrint(pasynUserSelf, ASYN_TRACE_ERROR, "%s:%s: AdsSyncReadReqEx2 failed: %s (%lu).\n", driverName, functionName,adsErrorToString(*error),*error);
     return asynError;
@@ -4370,34 +4580,13 @@ asynStatus adsAsynPortDriver::adsReadParam(adsParamInfo *paramInfo,long *error,i
  *
  * \return asynSuccess or asynError.
  */
-asynStatus adsAsynPortDriver::adsReadStateLock(uint16_t amsport,uint16_t *adsState,bool blockErrorMsg)
+asynStatus adsAsynPortDriver::adsReadState(uint16_t amsClientPort,uint16_t amsport,uint16_t *adsState,bool blockErrorMsg)
 {
   asynStatus stat;
-  lock();
+  
   long error=0;
-  stat=adsReadState(amsport,adsState,blockErrorMsg,&error);
-  unlock();
-  return stat;
-}
-
-/** Read state of amsport in TwinCAT
- *
- * \param[in] amsport Ams-prot.
- * \param[out] adsState State of ams-port (running, invalid, config..).
- * \param[in] blockErrorMsg Suppress error messages
- *            (used while trying to reconnect to avoid alot of error messages).
- * \param[out] error Error code.
- *
- * Thread safe.
- *
- * \return asynSuccess or asynError.
- */
-asynStatus adsAsynPortDriver::adsReadStateLock(uint16_t amsport,uint16_t *adsState,bool blockErrorMsg,long *error)
-{
-  asynStatus stat;
-  lock();
-  stat=adsReadState(amsport,adsState,blockErrorMsg,error);
-  unlock();
+  stat=adsReadState(amsClientPort,amsport,adsState,blockErrorMsg,&error);
+  
   return stat;
 }
 
@@ -4407,10 +4596,10 @@ asynStatus adsAsynPortDriver::adsReadStateLock(uint16_t amsport,uint16_t *adsSta
  *
  * \return asynSuccess or asynError.
  */
-asynStatus adsAsynPortDriver::adsReadState(uint16_t *adsState)
+asynStatus adsAsynPortDriver::adsReadState(uint16_t amsClientPort,uint16_t *adsState)
 {
   long error=0;
-  return adsReadState(amsportDefault_,adsState,false,&error);
+  return adsReadState(amsClientPort,amsportDefault_,adsState,false,&error);
 }
 
 /** Read state of amsport in TwinCAT
@@ -4423,7 +4612,7 @@ asynStatus adsAsynPortDriver::adsReadState(uint16_t *adsState)
  *
  * \return asynSuccess or asynError.
  */
-asynStatus adsAsynPortDriver::adsReadState(uint16_t amsport,uint16_t *adsState,bool blockErrorMsg,long *error)
+asynStatus adsAsynPortDriver::adsReadState(uint16_t amsClientPort,uint16_t amsport,uint16_t *adsState,bool blockErrorMsg,long *error)
 {
 
   const char* functionName = "adsReadState";
@@ -4432,10 +4621,10 @@ asynStatus adsAsynPortDriver::adsReadState(uint16_t amsport,uint16_t *adsState,b
   AmsAddr amsServer={remoteNetId_,amsport};
 
   uint16_t devState;
-  adsLock();
-  const long status = AdsSyncReadStateReqEx(adsPort_, &amsServer, adsState, &devState);
+  
+  const long status = AdsSyncReadStateReqEx(amsClientPort, &amsServer, adsState, &devState);
   *error=status;
-  adsUnlock();
+  
   if (status) {
     if(!blockErrorMsg){
       asynPrint(pasynUserSelf, ASYN_TRACE_ERROR, "%s:%s: ADS read state failed with: %s (0x%lx)\n",driverName, functionName,adsErrorToString(status),status);
@@ -4452,14 +4641,14 @@ asynStatus adsAsynPortDriver::adsReadState(uint16_t amsport,uint16_t *adsState,b
  *
  * \return asynSuccess or asynError.
  */
-asynStatus adsAsynPortDriver::adsWriteState(uint16_t amsport,uint16_t adsState)
+asynStatus adsAsynPortDriver::adsWriteState(uint16_t amsClientPort,uint16_t amsport,uint16_t adsState)
 {
   const char* functionName = "adsWriteState";
   asynPrint(pasynUserSelf,ASYN_TRACE_FLOW, "%s:%s: adsState = %s (%u)\n", driverName, functionName,adsStateToString(adsState),adsState);
 
   void *pData=NULL;
   AmsAddr amsServer={remoteNetId_,amsport};
-  const long status = AdsSyncWriteControlReqEx (adsPort_,&amsServer, adsState, 0, 0, pData);
+  const long status = AdsSyncWriteControlReqEx (amsClientPort,&amsServer, adsState, 0, 0, pData);
   if(status){
     asynPrint(pasynUserSelf, ASYN_TRACE_ERROR, "%s:%s: ADS write state failed with: %s (0x%lx)\n",driverName, functionName,adsErrorToString(status),status);
     return asynError;
@@ -4488,8 +4677,8 @@ adsParamInfo *adsAsynPortDriver::getAdsParamInfo(int index)
   const char* functionName = "getAdsParamInfo";
   asynPrint(pasynUserSelf,ASYN_TRACE_FLOW, "%s:%s: Get paramInfo for index: %d\n", driverName, functionName,index);
 
-  if(index<adsParamArrayCount_){
-    return pAdsParamArray_[index];
+  if(index<getAdsParamCount()){
+    return &adsParamArray_[index];
   }
   else{
     return NULL;
@@ -4652,7 +4841,7 @@ asynStatus adsAsynPortDriver::adsUpdateParameter(adsParamInfo* paramInfo,const v
           ret=setDoubleParam(paramInfo->paramIndex,(double)(*ADST_INT8Var));
           break;
         case asynParamInt8Array:
-          // handled in fireCallbacks()
+          arrayParamsToCallCallbacksFor_.push(paramInfo);
           ret=asynSuccess;
           break;
         default:
@@ -4674,7 +4863,7 @@ asynStatus adsAsynPortDriver::adsUpdateParameter(adsParamInfo* paramInfo,const v
           ret=setDoubleParam(paramInfo->paramIndex,(double)(*ADST_INT16Var));
           break;
         case asynParamInt16Array:
-          // handled in fireCallbacks()
+          arrayParamsToCallCallbacksFor_.push(paramInfo);
           ret=asynSuccess;
           break;
         default:
@@ -4695,7 +4884,7 @@ asynStatus adsAsynPortDriver::adsUpdateParameter(adsParamInfo* paramInfo,const v
           ret=setDoubleParam(paramInfo->paramIndex,(double)(*ADST_INT32Var));
           break;
         case asynParamInt32Array:
-          // handled in fireCallbacks()
+          arrayParamsToCallCallbacksFor_.push(paramInfo);
           ret=asynSuccess;
           break;
         default:
@@ -4720,7 +4909,7 @@ asynStatus adsAsynPortDriver::adsUpdateParameter(adsParamInfo* paramInfo,const v
           break;
         // No 64 bit uint array callback type (also no 64bit uint in EPICS)
         case asynParamInt64Array:
-          // handled in fireCallbacks()
+          arrayParamsToCallCallbacksFor_.push(paramInfo);
           ret=asynSuccess;
           break;
         default:
@@ -4798,7 +4987,7 @@ asynStatus adsAsynPortDriver::adsUpdateParameter(adsParamInfo* paramInfo,const v
           break;
         // No 64 bit uint array callback type (also no 64bit uint in EPICS)
         case asynParamInt64Array:
-          // handled in fireCallbacks()
+          arrayParamsToCallCallbacksFor_.push(paramInfo);
           ret=asynSuccess;
           break;
         default:
@@ -4818,7 +5007,7 @@ asynStatus adsAsynPortDriver::adsUpdateParameter(adsParamInfo* paramInfo,const v
           ret=setDoubleParam(paramInfo->paramIndex,(double)(*ADST_REAL32Var));
           break;
         case asynParamFloat32Array:
-          // handled in fireCallbacks()
+          arrayParamsToCallCallbacksFor_.push(paramInfo);
           ret=asynSuccess;
           break;
         default:
@@ -4838,7 +5027,7 @@ asynStatus adsAsynPortDriver::adsUpdateParameter(adsParamInfo* paramInfo,const v
           ret=setDoubleParam(paramInfo->paramIndex,(double)(*ADST_REAL64Var));
           break;
         case asynParamFloat64Array:
-          // handled in fireCallbacks()
+          arrayParamsToCallCallbacksFor_.push(paramInfo);
           ret=asynSuccess;
           break;
         default:
@@ -4859,7 +5048,7 @@ asynStatus adsAsynPortDriver::adsUpdateParameter(adsParamInfo* paramInfo,const v
           ret=setDoubleParam(paramInfo->paramIndex,(double)(*ADST_BitVar));
           break;
         case asynParamInt8Array:
-          // handled in fireCallbacks()
+          arrayParamsToCallCallbacksFor_.push(paramInfo);
           ret=asynSuccess;
           break;
         default:
@@ -4871,7 +5060,7 @@ asynStatus adsAsynPortDriver::adsUpdateParameter(adsParamInfo* paramInfo,const v
      case ADST_STRING:
       switch(paramInfo->asynType){
         case asynParamInt8Array:
-          // handled in fireCallbacks()
+          arrayParamsToCallCallbacksFor_.push(paramInfo);
           ret=asynSuccess;
           break;
         default:
@@ -4895,11 +5084,7 @@ asynStatus adsAsynPortDriver::adsUpdateParameter(adsParamInfo* paramInfo,const v
     return ret;
   }
 
-  if(allowCallbackEpicsState){
-    return fireCallbacks(paramInfo);
-  }
-
-   return asynSuccess;
+  return asynSuccess;
 }
 
 /** Call callbacks for all parameters.
@@ -4912,10 +5097,11 @@ asynStatus adsAsynPortDriver::fireAllCallbacksLock()
   asynPrint(pasynUserSelf,ASYN_TRACE_FLOW, "%s:%s:\n", driverName, functionName);
 
   lock();
-  for(int i=0;i<adsParamArrayCount_;i++){
-    if(pAdsParamArray_[i]){
-      fireCallbacks(pAdsParamArray_[i]);
-    }
+  callParamCallbacks();
+  while (!arrayParamsToCallCallbacksFor_.empty())
+  {
+    fireCallbacksForArrayParam(arrayParamsToCallCallbacksFor_.front());
+    arrayParamsToCallCallbacksFor_.pop();
   }
   unlock();
   return asynSuccess;
@@ -4927,13 +5113,12 @@ asynStatus adsAsynPortDriver::fireAllCallbacksLock()
  *
  * \return asynSuccess or asynError.
  */
-asynStatus adsAsynPortDriver::fireCallbacks(adsParamInfo* paramInfo)
+asynStatus adsAsynPortDriver::fireCallbacksForArrayParam(adsParamInfo* paramInfo)
 {
-  const char* functionName = "fireCallbacks";
-  asynPrint(pasynUserSelf,ASYN_TRACE_FLOW, "%s:%s:\n", driverName, functionName);
+  asynPrint(pasynUserSelf,ASYN_TRACE_FLOW, "%s:%s:\n", driverName, __func__);
 
   if(!paramInfo->plcDataIsArray){
-    return callParamCallbacks();
+    return asynSuccess;
   }
 
   if(paramInfo->lastCallbackSize<=0){
@@ -4950,7 +5135,10 @@ asynStatus adsAsynPortDriver::fireCallbacks(adsParamInfo* paramInfo)
           ret=doCallbacksInt8Array((epicsInt8 *)paramInfo->arrayDataBuffer,paramInfo->lastCallbackSize, paramInfo->paramIndex,paramInfo->asynAddr);
           break;
         default:
-          asynPrint(pasynUserSelf, ASYN_TRACE_ERROR, "%s:%s: Type combination not supported. PLC type = %s, ASYN type= %s\n", driverName, functionName,adsTypeToString(paramInfo->plcDataType),asynTypeToString(paramInfo->asynType));
+          asynPrint(pasynUserSelf, ASYN_TRACE_ERROR, 
+            "%s:%s: Type combination not supported. PLC type = %s, ASYN type= %s, Name= %s\n", 
+            driverName, __func__,adsTypeToString(paramInfo->plcDataType),asynTypeToString(paramInfo->asynType), 
+            paramInfo->plcAdrStr);
           return asynError;
           break;
       }
@@ -4962,7 +5150,10 @@ asynStatus adsAsynPortDriver::fireCallbacks(adsParamInfo* paramInfo)
           ret=doCallbacksInt16Array((epicsInt16 *)paramInfo->arrayDataBuffer,paramInfo->lastCallbackSize, paramInfo->paramIndex,paramInfo->asynAddr);
           break;
         default:
-          asynPrint(pasynUserSelf, ASYN_TRACE_ERROR, "%s:%s: Type combination not supported. PLC type = %s, ASYN type= %s\n", driverName, functionName,adsTypeToString(paramInfo->plcDataType),asynTypeToString(paramInfo->asynType));
+          asynPrint(pasynUserSelf, ASYN_TRACE_ERROR, 
+            "%s:%s: Type combination not supported. PLC type = %s, ASYN type= %s, Name= %s\n", 
+            driverName, __func__,adsTypeToString(paramInfo->plcDataType),asynTypeToString(paramInfo->asynType), 
+            paramInfo->plcAdrStr);
           return asynError;
           break;
       }
@@ -4973,8 +5164,10 @@ asynStatus adsAsynPortDriver::fireCallbacks(adsParamInfo* paramInfo)
           ret=doCallbacksInt32Array((epicsInt32 *)paramInfo->arrayDataBuffer,paramInfo->lastCallbackSize, paramInfo->paramIndex,paramInfo->asynAddr);
           break;
         default:
-          asynPrint(pasynUserSelf, ASYN_TRACE_ERROR, "%s:%s: Type combination not supported. PLC type = %s, ASYN type= %s\n", driverName, functionName,adsTypeToString(paramInfo->plcDataType),asynTypeToString(paramInfo->asynType));
-          return asynError;
+          asynPrint(pasynUserSelf, ASYN_TRACE_ERROR, 
+            "%s:%s: Type combination not supported. PLC type = %s, ASYN type= %s, Name= %s\n", 
+            driverName, __func__,adsTypeToString(paramInfo->plcDataType),asynTypeToString(paramInfo->asynType), 
+            paramInfo->plcAdrStr);return asynError;
           break;
       }
       break;
@@ -4984,8 +5177,10 @@ asynStatus adsAsynPortDriver::fireCallbacks(adsParamInfo* paramInfo)
           ret= doCallbacksInt64Array((epicsInt64 *)paramInfo->arrayDataBuffer, paramInfo->lastCallbackSize / sizeof(epicsInt64), paramInfo->paramIndex, paramInfo->asynAddr);
           break;
         default:
-          asynPrint(pasynUserSelf, ASYN_TRACE_ERROR, "%s:%s: Type combination not supported. PLC type = %s, ASYN type= %s\n", driverName, functionName,adsTypeToString(paramInfo->plcDataType),asynTypeToString(paramInfo->asynType));
-          return asynError;
+          asynPrint(pasynUserSelf, ASYN_TRACE_ERROR, 
+            "%s:%s: Type combination not supported. PLC type = %s, ASYN type= %s, Name= %s\n", 
+            driverName, __func__,adsTypeToString(paramInfo->plcDataType),asynTypeToString(paramInfo->asynType), 
+            paramInfo->plcAdrStr);return asynError;
           break;
       }
       break;
@@ -4996,8 +5191,10 @@ asynStatus adsAsynPortDriver::fireCallbacks(adsParamInfo* paramInfo)
           ret= doCallbacksInt64Array((epicsInt64 *)paramInfo->arrayDataBuffer, paramInfo->lastCallbackSize / sizeof(epicsInt64), paramInfo->paramIndex, paramInfo->asynAddr);
           break;
         default:
-          asynPrint(pasynUserSelf, ASYN_TRACE_ERROR, "%s:%s: Type combination not supported. PLC type = %s, ASYN type= %s\n", driverName, functionName,adsTypeToString(paramInfo->plcDataType),asynTypeToString(paramInfo->asynType));
-          return asynError;
+          asynPrint(pasynUserSelf, ASYN_TRACE_ERROR, 
+            "%s:%s: Type combination not supported. PLC type = %s, ASYN type= %s, Name= %s\n", 
+            driverName, __func__,adsTypeToString(paramInfo->plcDataType),asynTypeToString(paramInfo->asynType), 
+            paramInfo->plcAdrStr);return asynError;
           break;
       }
       break;
@@ -5007,8 +5204,10 @@ asynStatus adsAsynPortDriver::fireCallbacks(adsParamInfo* paramInfo)
           ret=doCallbacksFloat32Array((epicsFloat32 *)paramInfo->arrayDataBuffer,paramInfo->lastCallbackSize, paramInfo->paramIndex,paramInfo->asynAddr);
           break;
         default:
-          asynPrint(pasynUserSelf, ASYN_TRACE_ERROR, "%s:%s: Type combination not supported. PLC type = %s, ASYN type= %s\n", driverName, functionName,adsTypeToString(paramInfo->plcDataType),asynTypeToString(paramInfo->asynType));
-          return asynError;
+          asynPrint(pasynUserSelf, ASYN_TRACE_ERROR, 
+            "%s:%s: Type combination not supported. PLC type = %s, ASYN type= %s, Name= %s\n", 
+            driverName, __func__,adsTypeToString(paramInfo->plcDataType),asynTypeToString(paramInfo->asynType), 
+            paramInfo->plcAdrStr);return asynError;
           break;
       }
       break;
@@ -5019,8 +5218,10 @@ asynStatus adsAsynPortDriver::fireCallbacks(adsParamInfo* paramInfo)
           ret=doCallbacksFloat64Array((epicsFloat64 *)paramInfo->arrayDataBuffer,paramInfo->lastCallbackSize, paramInfo->paramIndex,paramInfo->asynAddr);
           break;
         default:
-          asynPrint(pasynUserSelf, ASYN_TRACE_ERROR, "%s:%s: Type combination not supported. PLC type = %s, ASYN type= %s\n", driverName, functionName,adsTypeToString(paramInfo->plcDataType),asynTypeToString(paramInfo->asynType));
-          return asynError;
+          asynPrint(pasynUserSelf, ASYN_TRACE_ERROR, 
+            "%s:%s: Type combination not supported. PLC type = %s, ASYN type= %s, Name= %s\n", 
+            driverName, __func__,adsTypeToString(paramInfo->plcDataType),asynTypeToString(paramInfo->asynType), 
+            paramInfo->plcAdrStr);return asynError;
           break;
       }
       break;
@@ -5031,8 +5232,10 @@ asynStatus adsAsynPortDriver::fireCallbacks(adsParamInfo* paramInfo)
           ret=doCallbacksInt8Array((epicsInt8 *) paramInfo->arrayDataBuffer,paramInfo->lastCallbackSize, paramInfo->paramIndex,paramInfo->asynAddr);
           break;
         default:
-          asynPrint(pasynUserSelf, ASYN_TRACE_ERROR, "%s:%s: Type combination not supported. PLC type = %s, ASYN type= %s\n", driverName, functionName,adsTypeToString(paramInfo->plcDataType),asynTypeToString(paramInfo->asynType));
-          return asynError;
+          asynPrint(pasynUserSelf, ASYN_TRACE_ERROR, 
+            "%s:%s: Type combination not supported. PLC type = %s, ASYN type= %s, Name= %s\n", 
+            driverName, __func__,adsTypeToString(paramInfo->plcDataType),asynTypeToString(paramInfo->asynType), 
+            paramInfo->plcAdrStr);return asynError;
           break;
       }
       break;
@@ -5042,15 +5245,19 @@ asynStatus adsAsynPortDriver::fireCallbacks(adsParamInfo* paramInfo)
           ret=doCallbacksInt8Array((epicsInt8 *) paramInfo->arrayDataBuffer,paramInfo->lastCallbackSize, paramInfo->paramIndex,paramInfo->asynAddr);
           break;
         default:
-          asynPrint(pasynUserSelf, ASYN_TRACE_ERROR, "%s:%s: Type combination not supported. PLC type = %s, ASYN type= %s\n", driverName, functionName,adsTypeToString(paramInfo->plcDataType),asynTypeToString(paramInfo->asynType));
-          return asynError;
+          asynPrint(pasynUserSelf, ASYN_TRACE_ERROR, 
+            "%s:%s: Type combination not supported. PLC type = %s, ASYN type= %s, Name= %s\n", 
+            driverName, __func__,adsTypeToString(paramInfo->plcDataType),asynTypeToString(paramInfo->asynType), 
+            paramInfo->plcAdrStr);return asynError;
           break;
         }
       break;
 
     default:
-      asynPrint(pasynUserSelf, ASYN_TRACE_ERROR, "%s:%s: Type combination not supported. PLC type = %s, ASYN type= %s\n", driverName, functionName,adsTypeToString(paramInfo->plcDataType),asynTypeToString(paramInfo->asynType));
-      return asynError;
+      asynPrint(pasynUserSelf, ASYN_TRACE_ERROR, 
+        "%s:%s: Type combination not supported. PLC type = %s, ASYN type= %s, Name= %s\n", 
+        driverName, __func__,adsTypeToString(paramInfo->plcDataType),asynTypeToString(paramInfo->asynType), 
+        paramInfo->plcAdrStr);return asynError;
       break;
   }
   return ret;
@@ -5082,8 +5289,6 @@ asynStatus adsAsynPortDriver::setAlarmParam(adsParamInfo *paramInfo,int alarm,in
     return asynError;
   }
 
-  bool doCallbacks=false;
-
   if(oldAlarmStatus!=alarm){
     stat=setParamAlarmStatus(paramInfo->paramIndex,alarm);
     if(stat!=asynSuccess){
@@ -5091,7 +5296,6 @@ asynStatus adsAsynPortDriver::setAlarmParam(adsParamInfo *paramInfo,int alarm,in
       return asynError;
     }
     paramInfo->alarmStatus=alarm;
-    doCallbacks=true;
   }
 
   int oldAlarmSeverity=0;
@@ -5108,46 +5312,6 @@ asynStatus adsAsynPortDriver::setAlarmParam(adsParamInfo *paramInfo,int alarm,in
       return asynError;
     }
     paramInfo->alarmSeverity=severity;
-    doCallbacks=true;
-  }
-
-  if(!doCallbacks || !allowCallbackEpicsState){
-    return asynSuccess;
-  }
-  //Write size used for arrays
-  size_t writeSize=paramInfo->arrayDataBufferSize;
-  if(paramInfo->plcSize<writeSize){
-    writeSize=paramInfo->plcSize;
-  }
-
-  //Alarm status or severity changed=>Do callbacks with old buffered data (if nElemnts==0 then no data in record...)
-  if(paramInfo->plcDataIsArray && paramInfo->arrayDataBuffer and paramInfo->arrayDataBufferSize>0 && allowCallbackEpicsState){
-    switch(paramInfo->asynType){
-      case asynParamInt8Array:
-        stat=doCallbacksInt8Array((epicsInt8 *)paramInfo->arrayDataBuffer,writeSize/sizeof(epicsInt8), paramInfo->paramIndex,paramInfo->asynAddr);
-        break;
-      case asynParamInt16Array:
-        stat=doCallbacksInt16Array((epicsInt16 *)paramInfo->arrayDataBuffer,writeSize/sizeof(epicsInt16), paramInfo->paramIndex,paramInfo->asynAddr);
-        break;
-      case asynParamInt32Array:
-        stat=doCallbacksInt32Array((epicsInt32 *)paramInfo->arrayDataBuffer,writeSize/sizeof(epicsInt32), paramInfo->paramIndex,paramInfo->asynAddr);
-        break;
-      case asynParamInt64Array:
-        stat=doCallbacksInt64Array((epicsInt64 *)paramInfo->arrayDataBuffer,writeSize/sizeof(epicsInt64), paramInfo->paramIndex,paramInfo->asynAddr);
-        break;
-      case asynParamFloat32Array:
-        stat=doCallbacksFloat32Array((epicsFloat32 *)paramInfo->arrayDataBuffer,writeSize/sizeof(epicsFloat32), paramInfo->paramIndex,paramInfo->asynAddr);
-        break;
-      case asynParamFloat64Array:
-        stat=doCallbacksFloat64Array((epicsFloat64 *)paramInfo->arrayDataBuffer,writeSize/sizeof(epicsFloat64), paramInfo->paramIndex,paramInfo->asynAddr);
-        break;
-      default:
-        stat=callParamCallbacks();
-        break;
-    }
-  }
-  else{
-      stat=callParamCallbacks();
   }
 
   return stat;
@@ -5186,30 +5350,13 @@ asynStatus adsAsynPortDriver::setAlarmPort(uint16_t amsPort,int alarm,int severi
   asynPrint(pasynUserSelf,ASYN_TRACE_FLOW, "%s:%s:\n", driverName, functionName);
 
   for(int i=0;i<adsParamArrayCount_;i++){
-    if(!pAdsParamArray_[i]){
-      continue;
-    }
-    if(pAdsParamArray_[i]->amsPort==amsPort){
-      if(setAlarmParam(pAdsParamArray_[i],alarm,severity)!=asynSuccess){
+    if(adsParamArray_[i].amsPort==amsPort){
+      if(setAlarmParam(&adsParamArray_[i],alarm,severity)!=asynSuccess){
         return asynError;
       }
     }
   }
   return asynSuccess;
-}
-
-/** Take adsLib lock.
- */
-void adsAsynPortDriver::adsLock()
-{
-  adsMutex.lock();
-}
-
-/** Release adsLib lock.
- */
-void adsAsynPortDriver::adsUnlock()
-{
-  adsMutex.unlock();
 }
 
 /** Delete ads route
@@ -5229,37 +5376,18 @@ asynStatus adsAsynPortDriver::adsDelRoute(int force)
   return asynSuccess;
 }
 
-/** Delete ads route
- *
- * \param[in] force Force delete.
- *
- * \return asynSuccess or asynError.
- *
- * Thread safe.
- */
-asynStatus adsAsynPortDriver::adsDelRouteLock(int force)
-{
-  adsLock();
-  asynStatus stat=adsDelRoute(force);
-  adsUnlock();
-  return stat;
-}
-
 /** Add ads route
  *
  * \return asynSuccess or asynError.
  *
- * Thread safe.
  */
-asynStatus adsAsynPortDriver::adsAddRouteLock()
+asynStatus adsAsynPortDriver::adsAddRoute()
 {
   const char* functionName = "adsAddRouteLock";
   asynPrint(pasynUserSelf,ASYN_TRACE_FLOW, "%s:%s:\n", driverName, functionName);
 
   // add local route to your ADS Master
-  adsLock();
   const long addRouteStatus = AdsAddRoute(remoteNetId_, ipaddr_);
-  adsUnlock();
   if(addRouteStatus){
     asynPrint(pasynUserSelf, ASYN_TRACE_ERROR, "%s:%s: Adding ADS route failed with: %s (0x%lx).\n", driverName, functionName,adsErrorToString(addRouteStatus),addRouteStatus);
     return asynError;
@@ -5385,7 +5513,7 @@ extern "C" {
                                          amsport,
                                          asynParamTableSize,
                                          priority,
-                                         noAutoConnect==0,
+                                         false, // we don't want asynPortDriver to manage connecting/disconnecting. We do that in constructor/cyclic thread
                                          defaultSampleTimeMS,
                                          maxDelayTimeMS,
                                          adsTimeoutMS,
@@ -5477,4 +5605,83 @@ extern "C" {
   }
 
   epicsExportRegistrar(adsAsynPortDriverRegister);
+}
+
+long adsAsynPortDriver::getAdsClientPortNumberForThreadId(epicsThreadId threadId)
+{
+  std::lock_guard<std::recursive_mutex> lockGuard(threadIdToAmsClientPortMapMutex_);
+
+  // If the map doesn't contain the thread id already, return the default one.
+  if (threadIdToAmsClientPortMap_.find(threadId) != threadIdToAmsClientPortMap_.end())
+    return threadIdToAmsClientPortMap_.at(0).port;
+
+  // Otherwise, get the ads client port assigned to the input threadId.
+  return threadIdToAmsClientPortMap_.at(threadId).port;
+}
+
+long adsAsynPortDriver::addAdsClientPortNumberForThreadId(epicsThreadId threadId)
+{
+  std::lock_guard<std::recursive_mutex> lockGuard(threadIdToAmsClientPortMapMutex_);
+
+  // If the map contains the thread id already, increment the live count
+  // and return the port number used for it.
+  auto it = threadIdToAmsClientPortMap_.find(threadId);
+  if (it != threadIdToAmsClientPortMap_.end())
+  {
+    it->second.liveCount++;
+    return it->second.port;
+  }
+
+  // If we get here, the thread id doesn't already have an ads client port assigned for it.
+  // In this case, open a new port for it.
+  auto adsClientPort = AdsPortOpenEx();
+  if (isInvalidPortNumber(adsClientPort))
+    return 0;
+
+  // Insert the new pair.
+  threadIdToAmsClientPortMap_.insert(std::make_pair(threadId, AmsClientPortEntry(adsClientPort, 1)));
+  return adsClientPort;
+}
+
+asynStatus adsAsynPortDriver::delAdsClientPortNumberForThreadId(epicsThreadId threadId)
+{
+  std::lock_guard<std::recursive_mutex> lockGuard(threadIdToAmsClientPortMapMutex_);
+
+  // If the map contains the thread id erase it.
+  auto it = threadIdToAmsClientPortMap_.find(threadId);
+  if (it != threadIdToAmsClientPortMap_.end())
+  {
+    it->second.liveCount--;
+    if (it->second.liveCount > 0)
+    {
+      // Do not close the port if the live count is still above 0.
+      // This means this thread is still using this port somewhere.
+      return asynSuccess;
+    }
+    auto result = AdsPortCloseEx(it->second.port);
+    if (result)
+    {
+      asynPrint(pasynUserSelf, ASYN_TRACE_WARNING,
+                "%s:%s: found thread id in map but failed to close port.\n", driverName, __func__);
+      return asynError;
+    }
+    threadIdToAmsClientPortMap_.erase(it);
+  }
+  return asynSuccess;
+}
+
+AdsClientPortGuard::AdsClientPortGuard(adsAsynPortDriver &adsAsynPortDriver, long &adsClientPort)
+    : adsAsynPortDriver_(adsAsynPortDriver)
+{
+  threadId_ = epicsThreadGetIdSelf();
+  adsClientPort_ = adsAsynPortDriver_.addAdsClientPortNumberForThreadId(threadId_);
+  adsClientPort = adsClientPort_;
+}
+AdsClientPortGuard::~AdsClientPortGuard()
+{
+  adsAsynPortDriver_.delAdsClientPortNumberForThreadId(threadId_);
+}
+long AdsClientPortGuard::getAdsClientPort() const
+{
+  return adsClientPort_;
 }

--- a/adsApp/src/adsAsynPortDriver.cpp
+++ b/adsApp/src/adsAsynPortDriver.cpp
@@ -278,9 +278,6 @@ static void adsSymbolsChangedCallback(const AmsAddr* pAddr, const AdsNotificatio
 static void adsDataCallback(const AmsAddr* pAddr, const AdsNotificationHeader* pNotification, uint32_t hUser)
 {
   const char* functionName = "adsDataCallback";
-
-  printf("%s:%s: got notification callback for hUser %u\n", driverName, functionName, hUser);
-
   if(!adsAsynPortObj){
     printf("%s:%s: ERROR: adsAsynPortObj==NULL\n", driverName, functionName);
     return;
@@ -311,8 +308,6 @@ static void adsDataCallback(const AmsAddr* pAddr, const AdsNotificationHeader* p
     asynPrint(asynTraceUser, ASYN_TRACE_ERROR, "%s:%s: getAdsParamInfo() for hUser %u failed\n", driverName, functionName,hUser);
     return;
   }
-
-  printf("%s:%s: got notification callback for variable %s\n", driverName, functionName, paramInfo->plcAdrStr);
 
   if(adsAsynPortObj->datacbqueue.size() > MAXCBQSIZE){
     asynPrint(asynTraceUser, ASYN_TRACE_ERROR, "%s:%s: datacbqueue at max size, skip %s (%d)\n", driverName, functionName, paramInfo->drvInfo, paramInfo->paramIndex);
@@ -1285,7 +1280,6 @@ void adsAsynPortDriver::dataCallbackThread()
         asynPrint(pasynUserSelf, ASYN_TRACEIO_DRIVER,"%s:%s: Run callback for parameter %s (%d).\n", driverName, functionName, info->paramInfo->drvInfo, info->paramInfo->paramIndex);
         info->paramInfo->plcTimeStampRaw = info->pNotification.nTimeStamp;
         info->paramInfo->lastCallbackSize = info->pNotification.cbSampleSize;
-        printf("%s:%s: data callback for %s updating parameter now.\n", driverName, functionName, info->paramInfo->plcAdrStr);
         adsUpdateParameterLock(info->paramInfo, info->data);
         // This free is for the malloc in adsDataCallback
         free(info->data);
@@ -4102,7 +4096,7 @@ asynStatus adsAsynPortDriver::adsAddDataCallback(uint16_t amsClientPort, adsPara
 
   uint32_t hNotify=0;
   
-  long addStatus = AdsSyncAddDeviceNotificationReqEx(amsClientPort,
+  long addStatus = AdsSyncAddDeviceNotificationReqEx(adsPort_,
                                                      &amsServer,
                                                      group,
                                                      offset,

--- a/adsApp/src/adsAsynPortDriver.cpp
+++ b/adsApp/src/adsAsynPortDriver.cpp
@@ -1661,9 +1661,12 @@ asynStatus adsAsynPortDriver::drvUserCreate(asynUser *pasynUser,const char *drvI
     return asynError;
   }
 
+   std::string drvInfoStr = drvInfo;
+
   int index=0;
-  asynStatus status=findParam(drvInfo,&index);
-  if(status==asynSuccess){
+  auto createdParamsMapIt = createdParamsMap_.find(drvInfoStr);
+  if(createdParamsMapIt != createdParamsMap_.end()){
+    index = createdParamsMapIt->second;
     asynPrint(pasynUser, ASYN_TRACE_FLOW, "%s:%s: Parameter index found at: %d for %s. \n", driverName, functionName,index,drvInfo);
     return asynPortDriver::drvUserCreate(pasynUser,drvInfo,pptypeName,psize);
   }
@@ -1690,7 +1693,7 @@ asynStatus adsAsynPortDriver::drvUserCreate(asynUser *pasynUser,const char *drvI
   paramInfo->bulkIndex = -1;
   paramInfo->bulkOffset = -1;
 
-  status=parsePlcInfofromDrvInfo(drvInfo,paramInfo);
+  auto status=parsePlcInfofromDrvInfo(drvInfo,paramInfo);
   if(status!=asynSuccess){
     return asynError;
   }
@@ -1736,6 +1739,7 @@ asynStatus adsAsynPortDriver::drvUserCreate(asynUser *pasynUser,const char *drvI
 
   pasynUser->timeout=(paramInfo->maxDelayTimeMS*2)/1000;
   adsParamArrayCount_++;
+  createdParamsMap_.insert(std::make_pair(drvInfoStr, index));
 
   if(!connectedAds_){
     //try to connect without error handling

--- a/adsApp/src/adsAsynPortDriver.cpp
+++ b/adsApp/src/adsAsynPortDriver.cpp
@@ -279,6 +279,8 @@ static void adsDataCallback(const AmsAddr* pAddr, const AdsNotificationHeader* p
 {
   const char* functionName = "adsDataCallback";
 
+  printf("%s:%s: got notification callback for hUser %u\n", driverName, functionName, hUser);
+
   if(!adsAsynPortObj){
     printf("%s:%s: ERROR: adsAsynPortObj==NULL\n", driverName, functionName);
     return;
@@ -309,6 +311,9 @@ static void adsDataCallback(const AmsAddr* pAddr, const AdsNotificationHeader* p
     asynPrint(asynTraceUser, ASYN_TRACE_ERROR, "%s:%s: getAdsParamInfo() for hUser %u failed\n", driverName, functionName,hUser);
     return;
   }
+
+  printf("%s:%s: got notification callback for variable %s\n", driverName, functionName, paramInfo->plcAdrStr);
+
   if(adsAsynPortObj->datacbqueue.size() > MAXCBQSIZE){
     asynPrint(asynTraceUser, ASYN_TRACE_ERROR, "%s:%s: datacbqueue at max size, skip %s (%d)\n", driverName, functionName, paramInfo->drvInfo, paramInfo->paramIndex);
     return;
@@ -1122,7 +1127,7 @@ void adsAsynPortDriver::cyclicThread()
     if(oneAmsConnectionOK){
       notConnectedCounter_=0;
     }
-    if (notConnectedCounter_ > 5)
+    if (notConnectedCounter_ > 1)
     {
       asynPrint(pasynUserSelf, ASYN_TRACE_ERROR, "cyclicThread: failed to re-establish connection to ams server... exiting ioc. will retry if on auto restart.\n");
       exit(-1);
@@ -1280,6 +1285,7 @@ void adsAsynPortDriver::dataCallbackThread()
         asynPrint(pasynUserSelf, ASYN_TRACEIO_DRIVER,"%s:%s: Run callback for parameter %s (%d).\n", driverName, functionName, info->paramInfo->drvInfo, info->paramInfo->paramIndex);
         info->paramInfo->plcTimeStampRaw = info->pNotification.nTimeStamp;
         info->paramInfo->lastCallbackSize = info->pNotification.cbSampleSize;
+        printf("%s:%s: data callback for %s updating parameter now.\n", driverName, functionName, info->paramInfo->plcAdrStr);
         adsUpdateParameterLock(info->paramInfo, info->data);
         // This free is for the malloc in adsDataCallback
         free(info->data);
@@ -1755,7 +1761,7 @@ asynStatus adsAsynPortDriver::drvUserCreate(asynUser *pasynUser,const char *drvI
 
   gettimeofday(&t1, NULL);
   long elapsed_us = (t1.tv_sec - t0.tv_sec) * 1000000L + (t1.tv_usec - t0.tv_usec);
-  asynPrint(pasynUser, ASYN_TRACE_INFO,
+  asynPrint(pasynUser, ASYN_TRACE_FLOW,
             "%s:%s: Parameter created: \"%s\" (index %d) [%4ld us].\n",
             driverName, functionName, drvInfo, index, elapsed_us);
 
@@ -5517,7 +5523,7 @@ extern "C" {
                                          amsport,
                                          asynParamTableSize,
                                          priority,
-                                         false, // we don't want asynPortDriver to manage connecting/disconnecting. We do that in constructor/cyclic thread
+                                         noAutoConnect==0,
                                          defaultSampleTimeMS,
                                          maxDelayTimeMS,
                                          adsTimeoutMS,

--- a/adsApp/src/adsAsynPortDriver.cpp
+++ b/adsApp/src/adsAsynPortDriver.cpp
@@ -252,16 +252,17 @@ static void adsSymbolsChangedCallback(const AmsAddr* pAddr, const AdsNotificatio
     return;
   }
 
+  asynUser *asynTraceUser=adsAsynPortObj->getTraceAsynUser();
+
   long amsClientPort = 0;
   AdsClientPortGuard adsClientPortGuard(*adsAsynPortObj, amsClientPort);
   if (isInvalidPortNumber(amsClientPort))
   {
-    throw std::runtime_error(string_format(
-        "%s:%s: failed to open ads client port for this thread.\n", 
-        driverName, __func__));
+    amsClientPort = adsAsynPortObj->getAdsClientPortNumberForThreadId(0);
+    asynPrint(asynTraceUser, ASYN_TRACE_ERROR, "%s:%s: failed to open ads client port for this thread. Using default.\n", 
+            driverName, __func__);
   }
 
-  asynUser *asynTraceUser=adsAsynPortObj->getTraceAsynUser();
   asynPrint(asynTraceUser, ASYN_TRACE_INFO , "%s:%s: Symbols changed for Ams-port %u.\n", driverName, functionName,pAddr->port);
 
   adsAsynPortObj->invalidateParamsLock(pAddr->port);
@@ -1043,9 +1044,9 @@ void adsAsynPortDriver::cyclicThread()
   AdsClientPortGuard adsClientPortGuard(*this, amsClientPort);
   if (isInvalidPortNumber(amsClientPort))
   {
-    throw std::runtime_error(string_format(
-        "%s:%s: failed to open ads client port for this thread.\n", 
-        driverName, __func__));
+    amsClientPort = this->getAdsClientPortNumberForThreadId(0);
+    asynPrint(pasynUserSelf, ASYN_TRACE_ERROR, "%s:%s: failed to open ads client port for this thread. Using default.\n", 
+            driverName, __func__);
   }
 
   const char* functionName = "cyclicThread";
@@ -1150,9 +1151,9 @@ void adsAsynPortDriver::bulkReadThread()
   AdsClientPortGuard adsClientPortGuard(*this, amsClientPort);
   if (isInvalidPortNumber(amsClientPort))
   {
-    throw std::runtime_error(string_format(
-        "%s:%s: failed to open ads client port for this thread.\n", 
-        driverName, __func__));
+    amsClientPort = this->getAdsClientPortNumberForThreadId(0);
+    asynPrint(pasynUserSelf, ASYN_TRACE_ERROR, "%s:%s: failed to open ads client port for this thread. Using default.\n", 
+            driverName, __func__);
   }
 
     const char* functionName = "bulkReadThread";
@@ -1408,14 +1409,7 @@ asynStatus adsAsynPortDriver::disconnectLock(asynUser *pasynUser)
 asynStatus adsAsynPortDriver::disconnect(asynUser *pasynUser)
 {
   const char* functionName = "disconnect";
-  asynPrint(pasynUser, ASYN_TRACE_FLOW, "%s:%s:\n", driverName, functionName);
-
-  asynStatus disconnectStatus=adsDisconnect();
-  if (disconnectStatus){
-    return asynError;
-  }
-  
-  connectedAds_ = 0;
+  asynPrint(pasynUser, ASYN_TRACE_ERROR, "%s:%s:\n", driverName, functionName);
 
   if(asynPortDriver::disconnect(pasynUser)!=asynSuccess){
     return asynError;
@@ -1550,9 +1544,9 @@ asynStatus adsAsynPortDriver::connect(asynUser *pasynUser)
   AdsClientPortGuard adsClientPortGuard(*this, amsClientPort);
   if (isInvalidPortNumber(amsClientPort))
   {
-    throw std::runtime_error(string_format(
-        "%s:%s: failed to open ads client port for this thread.\n", 
-        driverName, __func__));
+    amsClientPort = this->getAdsClientPortNumberForThreadId(0);
+    asynPrint(pasynUserSelf, ASYN_TRACE_ERROR, "%s:%s: failed to open ads client port for this thread. Using default.\n", 
+            driverName, __func__);
   }
 
   bool err=false;
@@ -1624,9 +1618,9 @@ asynStatus adsAsynPortDriver::drvUserCreate(asynUser *pasynUser,const char *drvI
   AdsClientPortGuard adsClientPortGuard(*this, amsClientPort);
   if (isInvalidPortNumber(amsClientPort))
   {
-    throw std::runtime_error(string_format(
-        "%s:%s: failed to open ads client port for this thread.\n", 
-        driverName, __func__));
+    amsClientPort = this->getAdsClientPortNumberForThreadId(0);
+    asynPrint(pasynUserSelf, ASYN_TRACE_ERROR, "%s:%s: failed to open ads client port for this thread. Using default.\n", 
+            driverName, __func__);
   }
 
   /* One-off: resolve all symbol info from TwinCAT on first call
@@ -2374,9 +2368,9 @@ asynStatus adsAsynPortDriver::readOctet(asynUser *pasynUser, char *value, size_t
   AdsClientPortGuard adsClientPortGuard(*this, amsClientPort);
   if (isInvalidPortNumber(amsClientPort))
   {
-    throw std::runtime_error(string_format(
-        "%s:%s: failed to open ads client port for this thread.\n", 
-        driverName, __func__));
+    amsClientPort = this->getAdsClientPortNumberForThreadId(0);
+    asynPrint(pasynUserSelf, ASYN_TRACE_ERROR, "%s:%s: failed to open ads client port for this thread. Using default.\n", 
+            driverName, __func__);
   }
 
   size_t thisRead = 0;
@@ -2488,9 +2482,9 @@ asynStatus adsAsynPortDriver::writeOctet(asynUser *pasynUser, const char *value,
   AdsClientPortGuard adsClientPortGuard(*this, amsClientPort);
   if (isInvalidPortNumber(amsClientPort))
   {
-    throw std::runtime_error(string_format(
-        "%s:%s: failed to open ads client port for this thread.\n", 
-        driverName, __func__));
+    amsClientPort = this->getAdsClientPortNumberForThreadId(0);
+    asynPrint(pasynUserSelf, ASYN_TRACE_ERROR, "%s:%s: failed to open ads client port for this thread. Using default.\n", 
+            driverName, __func__);
   }
 
   size_t thisWrite = 0;
@@ -2940,9 +2934,9 @@ asynStatus adsAsynPortDriver::readInt32(asynUser *pasynUser, epicsInt32 *value)
   AdsClientPortGuard adsClientPortGuard(*this, amsClientPort);
   if (isInvalidPortNumber(amsClientPort))
   {
-    throw std::runtime_error(string_format(
-        "%s:%s: failed to open ads client port for this thread.\n", 
-        driverName, __func__));
+    amsClientPort = this->getAdsClientPortNumberForThreadId(0);
+    asynPrint(pasynUserSelf, ASYN_TRACE_ERROR, "%s:%s: failed to open ads client port for this thread. Using default.\n", 
+            driverName, __func__);
   }
 
   int paramIndex = pasynUser->reason;
@@ -2980,9 +2974,9 @@ asynStatus adsAsynPortDriver::readFloat64(asynUser *pasynUser, epicsFloat64 *val
   AdsClientPortGuard adsClientPortGuard(*this, amsClientPort);
   if (isInvalidPortNumber(amsClientPort))
   {
-    throw std::runtime_error(string_format(
-        "%s:%s: failed to open ads client port for this thread.\n", 
-        driverName, __func__));
+    amsClientPort = this->getAdsClientPortNumberForThreadId(0);
+    asynPrint(pasynUserSelf, ASYN_TRACE_ERROR, "%s:%s: failed to open ads client port for this thread. Using default.\n", 
+            driverName, __func__);
   }
 
   int paramIndex = pasynUser->reason;
@@ -3016,9 +3010,9 @@ asynStatus adsAsynPortDriver::writeInt32(asynUser *pasynUser, epicsInt32 value)
   AdsClientPortGuard adsClientPortGuard(*this, amsClientPort);
   if (isInvalidPortNumber(amsClientPort))
   {
-    throw std::runtime_error(string_format(
-        "%s:%s: failed to open ads client port for this thread.\n", 
-        driverName, __func__));
+    amsClientPort = this->getAdsClientPortNumberForThreadId(0);
+    asynPrint(pasynUserSelf, ASYN_TRACE_ERROR, "%s:%s: failed to open ads client port for this thread. Using default.\n", 
+            driverName, __func__);
   }
 
   int paramIndex = pasynUser->reason;
@@ -3147,9 +3141,9 @@ asynStatus adsAsynPortDriver::readInt64(asynUser *pasynUser, epicsInt64 *value)
   AdsClientPortGuard adsClientPortGuard(*this, amsClientPort);
   if (isInvalidPortNumber(amsClientPort))
   {
-    throw std::runtime_error(string_format(
-        "%s:%s: failed to open ads client port for this thread.\n", 
-        driverName, __func__));
+    amsClientPort = this->getAdsClientPortNumberForThreadId(0);
+    asynPrint(pasynUserSelf, ASYN_TRACE_ERROR, "%s:%s: failed to open ads client port for this thread. Using default.\n", 
+            driverName, __func__);
   }
 
     int paramIndex = pasynUser->reason;
@@ -3180,9 +3174,9 @@ asynStatus adsAsynPortDriver::writeInt64(asynUser *pasynUser, epicsInt64 value)
   AdsClientPortGuard adsClientPortGuard(*this, amsClientPort);
   if (isInvalidPortNumber(amsClientPort))
   {
-    throw std::runtime_error(string_format(
-        "%s:%s: failed to open ads client port for this thread.\n", 
-        driverName, __func__));
+    amsClientPort = this->getAdsClientPortNumberForThreadId(0);
+    asynPrint(pasynUserSelf, ASYN_TRACE_ERROR, "%s:%s: failed to open ads client port for this thread. Using default.\n", 
+            driverName, __func__);
   }
 
     int paramIndex = pasynUser->reason;
@@ -3270,9 +3264,9 @@ asynStatus adsAsynPortDriver::writeFloat64(asynUser *pasynUser, epicsFloat64 val
   AdsClientPortGuard adsClientPortGuard(*this, amsClientPort);
   if (isInvalidPortNumber(amsClientPort))
   {
-    throw std::runtime_error(string_format(
-        "%s:%s: failed to open ads client port for this thread.\n", 
-        driverName, __func__));
+    amsClientPort = this->getAdsClientPortNumberForThreadId(0);
+    asynPrint(pasynUserSelf, ASYN_TRACE_ERROR, "%s:%s: failed to open ads client port for this thread. Using default.\n", 
+            driverName, __func__);
   }
 
   int paramIndex = pasynUser->reason;
@@ -3528,9 +3522,9 @@ asynStatus adsAsynPortDriver::readInt8Array(asynUser *pasynUser,epicsInt8 *value
   AdsClientPortGuard adsClientPortGuard(*this, amsClientPort);
   if (isInvalidPortNumber(amsClientPort))
   {
-    throw std::runtime_error(string_format(
-        "%s:%s: failed to open ads client port for this thread.\n", 
-        driverName, __func__));
+    amsClientPort = this->getAdsClientPortNumberForThreadId(0);
+    asynPrint(pasynUserSelf, ASYN_TRACE_ERROR, "%s:%s: failed to open ads client port for this thread. Using default.\n", 
+            driverName, __func__);
   }
 
   int paramIndex = pasynUser->reason;
@@ -3576,9 +3570,9 @@ asynStatus adsAsynPortDriver::writeInt8Array(asynUser *pasynUser, epicsInt8 *val
   AdsClientPortGuard adsClientPortGuard(*this, amsClientPort);
   if (isInvalidPortNumber(amsClientPort))
   {
-    throw std::runtime_error(string_format(
-        "%s:%s: failed to open ads client port for this thread.\n", 
-        driverName, __func__));
+    amsClientPort = this->getAdsClientPortNumberForThreadId(0);
+    asynPrint(pasynUserSelf, ASYN_TRACE_ERROR, "%s:%s: failed to open ads client port for this thread. Using default.\n", 
+            driverName, __func__);
   }
 
   int paramIndex = pasynUser->reason;
@@ -3619,9 +3613,9 @@ asynStatus adsAsynPortDriver::readInt16Array(asynUser *pasynUser,epicsInt16 *val
   AdsClientPortGuard adsClientPortGuard(*this, amsClientPort);
   if (isInvalidPortNumber(amsClientPort))
   {
-    throw std::runtime_error(string_format(
-        "%s:%s: failed to open ads client port for this thread.\n", 
-        driverName, __func__));
+    amsClientPort = this->getAdsClientPortNumberForThreadId(0);
+    asynPrint(pasynUserSelf, ASYN_TRACE_ERROR, "%s:%s: failed to open ads client port for this thread. Using default.\n", 
+            driverName, __func__);
   }
 
   long allowedType=ADST_INT16;
@@ -3652,9 +3646,9 @@ asynStatus adsAsynPortDriver::writeInt16Array(asynUser *pasynUser, epicsInt16 *v
   AdsClientPortGuard adsClientPortGuard(*this, amsClientPort);
   if (isInvalidPortNumber(amsClientPort))
   {
-    throw std::runtime_error(string_format(
-        "%s:%s: failed to open ads client port for this thread.\n", 
-        driverName, __func__));
+    amsClientPort = this->getAdsClientPortNumberForThreadId(0);
+    asynPrint(pasynUserSelf, ASYN_TRACE_ERROR, "%s:%s: failed to open ads client port for this thread. Using default.\n", 
+            driverName, __func__);
   }
 
   long allowedType=ADST_INT16;
@@ -3680,9 +3674,9 @@ asynStatus adsAsynPortDriver::readInt32Array(asynUser *pasynUser,epicsInt32 *val
   AdsClientPortGuard adsClientPortGuard(*this, amsClientPort);
   if (isInvalidPortNumber(amsClientPort))
   {
-    throw std::runtime_error(string_format(
-        "%s:%s: failed to open ads client port for this thread.\n", 
-        driverName, __func__));
+    amsClientPort = this->getAdsClientPortNumberForThreadId(0);
+    asynPrint(pasynUserSelf, ASYN_TRACE_ERROR, "%s:%s: failed to open ads client port for this thread. Using default.\n", 
+            driverName, __func__);
   }
 
   long allowedType=ADST_INT32;
@@ -3714,9 +3708,9 @@ asynStatus adsAsynPortDriver::writeInt32Array(asynUser *pasynUser, epicsInt32 *v
   AdsClientPortGuard adsClientPortGuard(*this, amsClientPort);
   if (isInvalidPortNumber(amsClientPort))
   {
-    throw std::runtime_error(string_format(
-        "%s:%s: failed to open ads client port for this thread.\n", 
-        driverName, __func__));
+    amsClientPort = this->getAdsClientPortNumberForThreadId(0);
+    asynPrint(pasynUserSelf, ASYN_TRACE_ERROR, "%s:%s: failed to open ads client port for this thread. Using default.\n", 
+            driverName, __func__);
   }
 
   long allowedType=ADST_INT32;
@@ -3742,9 +3736,9 @@ asynStatus adsAsynPortDriver::readFloat32Array(asynUser *pasynUser,epicsFloat32 
   AdsClientPortGuard adsClientPortGuard(*this, amsClientPort);
   if (isInvalidPortNumber(amsClientPort))
   {
-    throw std::runtime_error(string_format(
-        "%s:%s: failed to open ads client port for this thread.\n", 
-        driverName, __func__));
+    amsClientPort = this->getAdsClientPortNumberForThreadId(0);
+    asynPrint(pasynUserSelf, ASYN_TRACE_ERROR, "%s:%s: failed to open ads client port for this thread. Using default.\n", 
+            driverName, __func__);
   }
 
   long allowedType=ADST_REAL32;
@@ -3775,9 +3769,9 @@ asynStatus adsAsynPortDriver::writeFloat32Array(asynUser *pasynUser,epicsFloat32
   AdsClientPortGuard adsClientPortGuard(*this, amsClientPort);
   if (isInvalidPortNumber(amsClientPort))
   {
-    throw std::runtime_error(string_format(
-        "%s:%s: failed to open ads client port for this thread.\n", 
-        driverName, __func__));
+    amsClientPort = this->getAdsClientPortNumberForThreadId(0);
+    asynPrint(pasynUserSelf, ASYN_TRACE_ERROR, "%s:%s: failed to open ads client port for this thread. Using default.\n", 
+            driverName, __func__);
   }
 
   long allowedType=ADST_REAL32;
@@ -3794,9 +3788,9 @@ asynStatus adsAsynPortDriver::readInt64Array(asynUser *pasynUser, epicsInt64 *va
   AdsClientPortGuard adsClientPortGuard(*this, amsClientPort);
   if (isInvalidPortNumber(amsClientPort))
   {
-    throw std::runtime_error(string_format(
-        "%s:%s: failed to open ads client port for this thread.\n", 
-        driverName, __func__));
+    amsClientPort = this->getAdsClientPortNumberForThreadId(0);
+    asynPrint(pasynUserSelf, ASYN_TRACE_ERROR, "%s:%s: failed to open ads client port for this thread. Using default.\n", 
+            driverName, __func__);
   }
 
     long allowedType = ADST_INT64;
@@ -3819,9 +3813,9 @@ asynStatus adsAsynPortDriver::writeInt64Array(asynUser *pasynUser, epicsInt64 *v
   AdsClientPortGuard adsClientPortGuard(*this, amsClientPort);
   if (isInvalidPortNumber(amsClientPort))
   {
-    throw std::runtime_error(string_format(
-        "%s:%s: failed to open ads client port for this thread.\n", 
-        driverName, __func__));
+    amsClientPort = this->getAdsClientPortNumberForThreadId(0);
+    asynPrint(pasynUserSelf, ASYN_TRACE_ERROR, "%s:%s: failed to open ads client port for this thread. Using default.\n", 
+            driverName, __func__);
   }
 
     long allowedType = ADST_INT64;
@@ -3847,9 +3841,9 @@ asynStatus adsAsynPortDriver::readFloat64Array(asynUser *pasynUser,epicsFloat64 
   AdsClientPortGuard adsClientPortGuard(*this, amsClientPort);
   if (isInvalidPortNumber(amsClientPort))
   {
-    throw std::runtime_error(string_format(
-        "%s:%s: failed to open ads client port for this thread.\n", 
-        driverName, __func__));
+    amsClientPort = this->getAdsClientPortNumberForThreadId(0);
+    asynPrint(pasynUserSelf, ASYN_TRACE_ERROR, "%s:%s: failed to open ads client port for this thread. Using default.\n", 
+            driverName, __func__);
   }
 
   long allowedType=ADST_REAL64;
@@ -3880,9 +3874,9 @@ asynStatus adsAsynPortDriver::writeFloat64Array(asynUser *pasynUser,epicsFloat64
   AdsClientPortGuard adsClientPortGuard(*this, amsClientPort);
   if (isInvalidPortNumber(amsClientPort))
   {
-    throw std::runtime_error(string_format(
-        "%s:%s: failed to open ads client port for this thread.\n", 
-        driverName, __func__));
+    amsClientPort = this->getAdsClientPortNumberForThreadId(0);
+    asynPrint(pasynUserSelf, ASYN_TRACE_ERROR, "%s:%s: failed to open ads client port for this thread. Using default.\n", 
+            driverName, __func__);
   }
 
   long allowedType=ADST_REAL64;

--- a/adsApp/src/adsAsynPortDriver.cpp
+++ b/adsApp/src/adsAsynPortDriver.cpp
@@ -1411,6 +1411,12 @@ asynStatus adsAsynPortDriver::disconnect(asynUser *pasynUser)
   const char* functionName = "disconnect";
   asynPrint(pasynUser, ASYN_TRACE_FLOW, "%s:%s:\n", driverName, functionName);
 
+  // EtherCATMC appears to call disconnect sometimes.
+  // adsDisconnect deletes the route, so this would cause all communication
+  // in the ioc to fail.
+  // Removed adsConnect call from here because we shouldn't ever need
+  // to delete our route to achieve something.
+
   if(asynPortDriver::disconnect(pasynUser)!=asynSuccess){
     return asynError;
   }

--- a/adsApp/src/adsAsynPortDriver.h
+++ b/adsApp/src/adsAsynPortDriver.h
@@ -108,9 +108,8 @@ public:
   asynStatus adsUpdateParameterLock(adsParamInfo* paramInfo,
                                     const void *data);
   asynStatus invalidateParamsLock(uint16_t amsPort);
-  asynStatus refreshParamsLock(uint16_t amsPort);
-  asynStatus adsDelRouteLock(int force);
-  asynStatus adsAddRouteLock();
+  asynStatus refreshParamsLock(uint16_t amsClientPort, uint16_t amsPort);
+  asynStatus adsAddRoute();
   asynStatus fireAllCallbacksLock();
   asynUser *getTraceAsynUser();
   int getParamTableSize();
@@ -122,6 +121,7 @@ public:
   void cyclicThread();
   void bulkReadThread();
   void dataCallbackThread();
+  void triggerEpicsIoIntrCallbacksThread();
   void poll_info(char *name);
   // data callback thread
 #define MAXCBQSIZE 10000
@@ -131,6 +131,10 @@ public:
     const AdsNotificationHeader  pNotification;
   };
   std::queue<datacbinfo>         datacbqueue;
+  
+  long getAdsClientPortNumberForThreadId(epicsThreadId threadId);
+  long addAdsClientPortNumberForThreadId(epicsThreadId threadId);
+  asynStatus delAdsClientPortNumberForThreadId(epicsThreadId threadId);
 protected:
 
 private:
@@ -143,8 +147,8 @@ private:
                                       adsParamInfo *paramInfo);
   asynStatus parsePlcInfofromDrvInfo(const char* drvInfo,
                                      adsParamInfo *paramInfo);
-  asynStatus refreshParams();
-  asynStatus refreshParams(uint16_t amsPort);
+  asynStatus refreshParams(uint16_t amsClientPort);
+  asynStatus refreshParams(uint16_t amsClientPort, uint16_t amsPort);
   asynStatus invalidateParams(uint16_t amsPort);
   asynStatus adsUpdateParameter(adsParamInfo* paramInfo,
                                  const void *data);
@@ -155,98 +159,92 @@ private:
                                     size_t dataSize);
 
   // ADS methods
-  asynStatus adsAddDataCallback(adsParamInfo *paramInfo);
+  asynStatus adsAddDataCallback(uint16_t amsClientPort, adsParamInfo *paramInfo);
 
-  asynStatus adsDelDataCallback(adsParamInfo *paramInfo);
-  asynStatus adsDelDataCallback(adsParamInfo *paramInfo,
+  asynStatus adsDelDataCallback(uint16_t amsClientPort, adsParamInfo *paramInfo);
+  asynStatus adsDelDataCallback(uint16_t amsClientPort, adsParamInfo *paramInfo,
                                         bool blockErrorMsg);
-  asynStatus adsAddSymbolsChangedCallback(amsPortInfo *port);
-  asynStatus adsDelSymbolsChangedCallback(amsPortInfo *port);
-  asynStatus adsGetSymInfoByName(adsParamInfo *paramInfo);
-  asynStatus adsGetSymInfoByName(uint16_t amsPort,
+  asynStatus adsAddSymbolsChangedCallback(uint16_t amsClientPort, amsPortInfo *port);
+  asynStatus adsDelSymbolsChangedCallback(uint16_t amsClientPort, amsPortInfo *port);
+  asynStatus adsGetSymInfoByName(uint16_t amsClientPort, adsParamInfo *paramInfo);
+  asynStatus adsGetSymInfoByName(uint16_t amsClientPort, uint16_t amsPort,
                                  const char * varName,
                                  adsSymbolEntry * info);
-  asynStatus adsGetSymInfoByName(uint16_t amsPort,
+  asynStatus adsGetSymInfoByName(uint16_t amsClientPort, uint16_t amsPort,
                                  const char *varName,
                                  adsSymbolEntry *info,
                                  long *errorCode);
-  asynStatus adsGetSymHandleByName(adsParamInfo *paramInfo);
-  asynStatus adsGetSymHandleByName(adsParamInfo *paramInfo,
+  asynStatus adsGetSymHandleByName(uint16_t amsClientPort, adsParamInfo *paramInfo);
+  asynStatus adsGetSymHandleByName(uint16_t amsClientPort, adsParamInfo *paramInfo,
                                    bool blockErrorMsg);
-  asynStatus adsReleaseSymbolicHandle(adsParamInfo *paramInfo);
-  asynStatus adsReleaseSymbolicHandle(adsParamInfo *paramInfo,
+  asynStatus adsReleaseSymbolicHandle(uint16_t amsClientPort, adsParamInfo *paramInfo);
+  asynStatus adsReleaseSymbolicHandle(uint16_t amsClientPort, adsParamInfo *paramInfo,
                                       bool blockErrorMsg);
-  asynStatus adsConnect();
+  asynStatus adsConnect(uint16_t amsClientPort);
   asynStatus adsDisconnect();
-  asynStatus adsWriteParam(adsParamInfo *paramInfo,
+  asynStatus adsWriteParam(uint16_t amsClientPort, adsParamInfo *paramInfo,
                       const void *binaryBuffer,
                       uint32_t bytesToWrite);
-  asynStatus adsReadParam(adsParamInfo *paramInfo);
-  asynStatus adsReadParam(adsParamInfo *paramInfo,
+  asynStatus adsReadParam(uint16_t amsClientPort, adsParamInfo *paramInfo);
+  asynStatus adsReadParam(uint16_t amsClientPort, adsParamInfo *paramInfo,
                           long *error,
                           int updateAsynPar);
-  asynStatus adsReadState(uint16_t *adsState);
-  asynStatus adsReadStateLock(uint16_t amsport,
+  asynStatus adsReadState(uint16_t amsClientPort, uint16_t *adsState);
+  asynStatus adsReadState(uint16_t amsClientPort, uint16_t amsport,
                               uint16_t *adsState,
                               bool blockErrorMsg);
-  asynStatus adsReadStateLock(uint16_t amsport,
+  asynStatus adsReadState(uint16_t amsClientPort, uint16_t amsport,
                               uint16_t *adsState,
                               bool blockErrorMsg,
                               long *error);
-  asynStatus adsReadState(uint16_t amsport,
-                          uint16_t *adsState,
-                          bool blockErrorMsg,
-                          long *error);
-  asynStatus adsWriteState(uint16_t amsport,
+  asynStatus adsWriteState(uint16_t amsClientPort, uint16_t amsport,
                           uint16_t adsState);
 
   asynStatus adsDelRoute(int force);
-  asynStatus adsGenericArrayWrite(asynUser *pasynUser,
+  asynStatus adsGenericArrayWrite(uint16_t amsClientPort, asynUser *pasynUser,
                                   long allowedType,
                                   const void *epicsDataBuffer,
                                   size_t nEpicsBufferBytes);
-  asynStatus adsGenericArrayRead(asynUser *pasynUser,
+  asynStatus adsGenericArrayRead(uint16_t amsClientPort, asynUser *pasynUser,
                                  long allowedType,
                                  void *epicsDataBuffer,
                                  size_t nEpicsBufferBytes,
                                  size_t *nBytesRead);
-  asynStatus adsReadVersion(amsPortInfo *port);
-  asynStatus updateParamInfoWithPLCInfo(adsParamInfo *paramInfo);
+  asynStatus adsReadVersion(uint16_t amsClientPort, amsPortInfo *port);
+  asynStatus updateParamInfoWithPLCInfo(uint16_t amsClientPort, adsParamInfo *paramInfo);
   asynStatus refreshParamTime(adsParamInfo *paramInfo);
   asynStatus setAlarmPortLock(uint16_t amsPort,int alarm,int severity);
   asynStatus setAlarmPort(uint16_t amsPort,int alarm,int severity);
   asynStatus setAlarmParam(adsParamInfo *paramInfo,int alarm,int severity);
-  asynStatus fireCallbacks(adsParamInfo* paramInfo);
+  asynStatus fireCallbacksForArrayParam(adsParamInfo* paramInfo);
   asynStatus addNewAmsPortToList(uint16_t amsPort);
   amsPortInfo* getAmsPortObject(uint16_t amsPort);
-  void       adsLock();
-  void       adsUnlock();
-  asynStatus adsAddToBulkRead(adsParamInfo* paramInfo);
-  int        adsFindBulkTimeStamp(uint16_t amsPort);
+  asynStatus adsAddToBulkRead(uint16_t amsClientPort, adsParamInfo* paramInfo);
+  int        adsFindBulkTimeStamp(uint16_t amsClientPort, uint16_t amsPort);
 
   //Octet interface methods (ascii command parser through readoctet() and writeoctet())
-  int        octetCMDreadIt(char *outbuf,
+  int        octetCMDreadIt(uint16_t amsClientPort, char *outbuf,
                             size_t outlen);
-  int        octetCMDwriteIt(const char *inbuf,
+  int        octetCMDwriteIt(uint16_t amsClientPort, const char *inbuf,
                              size_t inlen);
-  int        octetCmdHandleInputLine(const char *input_line,
+  int        octetCmdHandleInputLine(uint16_t amsClientPort, const char *input_line,
                                      adsOctetOutputBufferType *buffer);
-  int        octetMotorHandleOneArg(const char *myarg_1,
+  int        octetMotorHandleOneArg(uint16_t amsClientPort, const char *myarg_1,
                                     adsOctetOutputBufferType *buffer);
-  int        octetMotorHandleADRCmd(const char *arg,
+  int        octetMotorHandleADRCmd(uint16_t amsClientPort, const char *arg,
                                     uint16_t adsport,
                                     adsOctetOutputBufferType *buffer);
-  int        octetAdsReadByName(uint16_t amsPort,
+  int        octetAdsReadByName(uint16_t amsClientPort, uint16_t amsPort,
                                 const char *variableAddr,
                                 adsOctetOutputBufferType* outBuffer);
-  int        octetAdsWriteByName(uint16_t amsPort,
+  int        octetAdsWriteByName(uint16_t amsClientPort, uint16_t amsPort,
                                  const char *variableAddr,
                                  const char *asciiValueToWrite,
                                  adsOctetOutputBufferType *outBuffer);
-  int        octetAdsReadByGroupOffset(uint16_t amsPort,
+  int        octetAdsReadByGroupOffset(uint16_t amsClientPort, uint16_t amsPort,
                                        adsSymbolEntry *info,
                                        adsOctetOutputBufferType *outBuffer);
-  int        octetAdsWriteByGroupOffset(uint16_t amsPort,
+  int        octetAdsWriteByGroupOffset(uint16_t amsClientPort, uint16_t amsPort,
                                         uint32_t group,
                                         uint32_t offset,
                                         uint16_t dataType,
@@ -270,10 +268,14 @@ private:
   uint16_t                       amsportDefault_;
   unsigned int                   priority_;
   AmsNetId                       remoteNetId_;
-  adsParamInfo                   **pAdsParamArray_;
+  std::vector<adsParamInfo>      adsParamArray_;
   std::vector<amsPortInfo*>      amsPortList_;
   ADSTIMESOURCE                  defaultTimeSource_;
-  std::mutex                     adsMutex;
+  std::unordered_map<epicsThreadId, AmsClientPortEntry> threadIdToAmsClientPortMap_;
+  std::recursive_mutex threadIdToAmsClientPortMapMutex_;
+  std::unordered_map<std::string, int> createdParamsMap_;
+  std::mutex bulkReadInfoMutex_;
+  std::queue<adsParamInfo*> arrayParamsToCallCallbacksFor_;
 
   //octet
   adsOctetOutputBufferType       octetAsciiBuffer_;
@@ -291,7 +293,7 @@ private:
   int bulkTScnt;
 #define MAXBULK 2000
 #define BULKSIZ 500
-  struct {
+  struct BulkReadInfo {
       int cnt;               // Number of variables in this read
       uint16_t amsPort;      // The port this goes to!
       struct {
@@ -320,9 +322,23 @@ private:
 
 // member declarations
 std::unordered_map<std::string, AdsSymbolDictEntry> symbolDict_;
-asynStatus resolveSymbolInfo();
-asynStatus resolveSymbolHandles();
+asynStatus resolveSymbolInfo(uint16_t amsClientPort);
+asynStatus resolveSymbolHandles(uint16_t amsClientPort);
 bool symInfoResolved_ = false;
 };
+
+class AdsClientPortGuard
+{
+public:
+  AdsClientPortGuard(adsAsynPortDriver &adsAsynPortDriver, long &adsClientPort);
+  ~AdsClientPortGuard();
+  long getAdsClientPort() const;
+
+private:
+  adsAsynPortDriver &adsAsynPortDriver_;
+  long adsClientPort_;
+  epicsThreadId threadId_;
+};
+
 
 #endif /* ADSASYNPORTDRIVER_H_ */

--- a/adsApp/src/adsAsynPortDriverUtils.cpp
+++ b/adsApp/src/adsAsynPortDriverUtils.cpp
@@ -1154,3 +1154,35 @@ int octetAscii2binary(const char *asciiBuffer,uint16_t dataType,void *binaryBuff
 
   return error;
 }
+
+AmsClientPortEntry::AmsClientPortEntry(long port, int liveCount) : port(port), liveCount(liveCount) {}
+
+bool isInvalidPortNumber(long clientPortNumber)
+{
+  return (clientPortNumber) <= 0 || (clientPortNumber) > UINT16_MAX;
+}
+
+std::string string_format(const char *fmt, ...)
+{
+  va_list args;
+
+  // First, determine the size needed
+  va_start(args, fmt);
+  int size = std::vsnprintf(nullptr, 0, fmt, args);
+  va_end(args);
+
+  if (size < 0)
+  {
+    throw std::runtime_error("Formatting error");
+  }
+
+  // Allocate string of the required size
+  std::vector<char> buffer(size + 1);
+
+  // Format into the buffer
+  va_start(args, fmt);
+  std::vsnprintf(buffer.data(), buffer.size(), fmt, args);
+  va_end(args);
+
+  return std::string(buffer.data(), size);
+}

--- a/adsApp/src/adsAsynPortDriverUtils.h
+++ b/adsApp/src/adsAsynPortDriverUtils.h
@@ -51,50 +51,50 @@ typedef enum{
 } ADSDATASOURCE;
 
 typedef struct adsParamInfo{
-  char           *recordName;
-  char           *recordType;
-  char           *scan;
-  char           *dtyp;
-  char           *inp;
-  char           *out;
-  char           *drvInfo;
-  asynParamType  asynType;
-  int            asynAddr;
-  bool           isIOIntr;
-  double         sampleTimeMS;  //milli seconds
-  double         maxDelayTimeMS;  //milli seconds
-  uint16_t       amsPort;
-  int            paramIndex;  //also used as hUser for ads callback
-  bool           plcAbsAdrValid;  //Symbolic address converted to abs address or .ADR. command parsed
-  bool           isAdrCommand;
-  bool           isBulkRead;
-  double         pollClass;
-  char           *plcAdrStr;
-  uint32_t       plcAbsAdrGroup;
-  uint32_t       plcAbsAdrOffset;
-  uint32_t       plcSize;
-  uint32_t       plcDataType;
-  bool           plcDataTypeWarn;
-  bool           plcDataIsArray;
-  uint32_t       hCallbackNotify;
-  bool           bCallbackNotifyValid;
-  uint32_t       hSymbolicHandle;
-  bool           bSymbolicHandleValid;
-  size_t         lastCallbackSize;
-  size_t         arrayDataBufferSize;
-  void*          arrayDataBuffer;
-  bool           refreshNeeded;  //Communication broken update handles and callbacks
-  ADSDATASOURCE  dataSource;          //Variable in PLC or in driver (not in PLC)
+  char           *recordName = nullptr;
+  char           *recordType = nullptr;
+  char           *scan = nullptr;
+  char           *dtyp = nullptr;
+  char           *inp = nullptr;
+  char           *out = nullptr;
+  char           *drvInfo = nullptr;
+  asynParamType  asynType = asynParamType::asynParamNotDefined;
+  int            asynAddr = 0;
+  bool           isIOIntr = false;
+  double         sampleTimeMS = 0;  //milli seconds
+  double         maxDelayTimeMS = 0;  //milli seconds
+  uint16_t       amsPort = 0;
+  int            paramIndex = 0;  //also used as hUser for ads callback
+  bool           plcAbsAdrValid = false;  //Symbolic address converted to abs address or .ADR. command parsed
+  bool           isAdrCommand = false;
+  bool           isBulkRead = false;
+  double         pollClass = 0;
+  char           *plcAdrStr = nullptr;
+  uint32_t       plcAbsAdrGroup = 0;
+  uint32_t       plcAbsAdrOffset = 0;
+  uint32_t       plcSize = 0;
+  uint32_t       plcDataType = 0;
+  bool           plcDataTypeWarn = false;
+  bool           plcDataIsArray = false;
+  uint32_t       hCallbackNotify = 0;
+  bool           bCallbackNotifyValid = false;
+  uint32_t       hSymbolicHandle = 0;
+  bool           bSymbolicHandleValid = false;
+  size_t         lastCallbackSize = 0;
+  size_t         arrayDataBufferSize = 0;
+  void*          arrayDataBuffer = nullptr;
+  bool           refreshNeeded = false;  //Communication broken update handles and callbacks
+  ADSDATASOURCE  dataSource = ADSDATASOURCE::ADS_DATASOURCE_PLC; //Variable in PLC or in driver (not in PLC)
   //timing
-  ADSTIMESOURCE  timeBase;
-  uint64_t       plcTimeStampRaw;
-  epicsTimeStamp plcTimeStamp;
-  epicsTimeStamp epicsTimestamp;
-  int            alarmStatus;
-  int            alarmSeverity;
-  bool           firstReadDone;
-  int            bulkIndex;
-  int            bulkOffset;
+  ADSTIMESOURCE  timeBase = ADSTIMESOURCE::ADS_TIME_BASE_PLC;
+  uint64_t       plcTimeStampRaw = 0;
+  epicsTimeStamp plcTimeStamp = {0, 0};
+  epicsTimeStamp epicsTimestamp = {0, 0};
+  int            alarmStatus = 0;
+  int            alarmSeverity = 0;
+  bool           firstReadDone = false;
+  int            bulkIndex = 0;
+  int            bulkOffset = 0;
 }adsParamInfo;
 
 typedef struct amsPortInfo{
@@ -197,8 +197,16 @@ int octetAscii2binary(const char *asciiBuffer,
                       void *binaryBuffer,
                       uint32_t binaryBufferSize,
                       uint32_t *bytesProcessed);
+                                            
+struct AmsClientPortEntry
+{
+  AmsClientPortEntry(long port, int liveCount);
+  long port;
+  int liveCount;
+};
+
+bool isInvalidPortNumber(long clientPortNumber);
+
+std::string string_format(const char *fmt, ...);
 
 #endif /* ADSASYNPORTDRIVERUTILS_H_ */
-
-
-


### PR DESCRIPTION
- Moved callbacks to all occur within a single dedicated thread that has highest priority.
- Added support for every thread getting its own ams client port, except for adding notification requests. The ams client port that created a notification request must not be closed for the life of the notification callback.
- Instead of using findParam (O(N)) lookup to check for duplicate records, now caches records in hash table as we create them so we can do O(1) lookups to check for duplicate records. Unfortunately we cannot do anything about findParam call in createParam for now.
- Slightly modified cyclic thread to allow 1 failed connections before quitting on the second. So two failures must occur in a row before quitting.
- Made it so when asyn calls disconnect it doesn't delete the route. Ioc seems to do this spuriously and it causes everything to fail. This looks like it may be coming from Ethercat mc..