### PR TITLE
stop overwriting ams port to default in getRecordInfoFromDrvInfo

### DIFF
--- a/adsApp/src/adsAsynPortDriver.cpp
+++ b/adsApp/src/adsAsynPortDriver.cpp
@@ -2555,8 +2555,6 @@ asynStatus adsAsynPortDriver::getRecordInfoFromDrvInfo(const char* drvInfo, adsP
     asynPrint(
         pasynUserSelf, ASYN_TRACE_FLOW, "%s:%s: drvInfo: %s\n", driverName, functionName, drvInfo);
 
-    paramInfo->amsPort =
-        amsportDefault_; // will need to improve this later to use ams server port of param.
 
     /* Build cache on first call — O(N) scan of entire database, done once. */
     buildDrvInfoCache();


### PR DESCRIPTION
https://jira.slac.stanford.edu/browse/ECS-9097

.ADR. was not working with the POLL_RATE option for the cycle exceed count. The order of getRecordInfoFromDrvInfo and parseplcinfofromdrvinfo was swapped at some point, and getRecordInfoFromDrvInfo sets the ams to 851 (the default port) but the cycle exceed count is read directly from plc task ports. (350, 351). Tested and working on plc-tst-mkr-01 and plc-tst-mkr-02 on a bare IOC with just the exceed count pv using the poll rate option and a "normal" pv that I use to intentionall cause an exceed, after which I can see the exceed count pv change value in a camonitor process. 

https://github.com/pcdshub/twincat-ads/blob/e83c96ad81c9e8fa2057e1480b9c81d2048c2123/adsApp/src/adsAsynPortDriver.cpp#L2168 is the only place where getRecordInfoFromDrvInfo is called, and before it is called, parsePlcInfofromDrvInfo is called
https://github.com/pcdshub/twincat-ads/blob/e83c96ad81c9e8fa2057e1480b9c81d2048c2123/adsApp/src/adsAsynPortDriver.cpp#L2160
which executes this block of code that first sets the port to the default and then to whatever was specified by the ADS_OPTION_ADSPORT if present
https://github.com/pcdshub/twincat-ads/blob/e83c96ad81c9e8fa2057e1480b9c81d2048c2123/adsApp/src/adsAsynPortDriver.cpp#L2858-L2892