### PR TITLE
MNT(driver): stop and join worker threads before destroying the driver

### DIFF
--- a/adsApp/src/adsAsynPortDriver.cpp
+++ b/adsApp/src/adsAsynPortDriver.cpp
@@ -1148,13 +1148,15 @@ adsAsynPortDriver::adsAsynPortDriver(const char* portName,
     }
 
     //* Create the thread that computes the waveforms in the background */
-    status = (asynStatus)(epicsThreadCreate("adsAsynPortDriverCyclicThread",
-                                            epicsThreadPriorityMedium,
-                                            epicsThreadGetStackSize(epicsThreadStackMedium),
-                                            (EPICSTHREADFUNC)::cyclicThread,
-                                            this) == NULL);
-
-    if (status)
+    {
+        epicsThreadOpts opts = EPICS_THREAD_OPTS_INIT;
+        opts.priority        = epicsThreadPriorityMedium;
+        opts.stackSize       = epicsThreadGetStackSize(epicsThreadStackMedium);
+        opts.joinable        = 1; // joined in ~adsAsynPortDriver()
+        cyclicThreadId_      = epicsThreadCreateOpt(
+            "adsAsynPortDriverCyclicThread", (EPICSTHREADFUNC)::cyclicThread, this, &opts);
+    }
+    if (cyclicThreadId_ == NULL)
     {
         printf("%s:%s: epicsThreadCreate failure\n", driverName, functionName);
         return;
@@ -1180,37 +1182,49 @@ adsAsynPortDriver::adsAsynPortDriver(const char* portName,
     bulk_elapsed_us = 0;
 
     //* Create the thread that does the bulk reads */
-    status = (asynStatus)(epicsThreadCreate("adsAsynPortDriverBulkReadThread",
-                                            epicsThreadPriorityMedium,
-                                            epicsThreadGetStackSize(epicsThreadStackMedium),
-                                            (EPICSTHREADFUNC)::bulkReadThread,
-                                            this) == NULL);
-
-    if (status)
+    {
+        epicsThreadOpts opts = EPICS_THREAD_OPTS_INIT;
+        opts.priority        = epicsThreadPriorityMedium;
+        opts.stackSize       = epicsThreadGetStackSize(epicsThreadStackMedium);
+        opts.joinable        = 1; // joined in ~adsAsynPortDriver()
+        bulkReadThreadId_    = epicsThreadCreateOpt(
+            "adsAsynPortDriverBulkReadThread", (EPICSTHREADFUNC)::bulkReadThread, this, &opts);
+    }
+    if (bulkReadThreadId_ == NULL)
     {
         printf("%s:%s: epicsThreadCreate failure\n", driverName, functionName);
         return;
     }
     //* Create the thread that does the ADS subscription callbacks */
-    status = (asynStatus)(epicsThreadCreate("adsAsynPortDriverDataCallbackThread",
-                                            epicsThreadPriorityMedium,
-                                            epicsThreadGetStackSize(epicsThreadStackMedium),
-                                            (EPICSTHREADFUNC)::dataCallbackThread,
-                                            this) == NULL);
-
-    if (status)
+    {
+        epicsThreadOpts opts  = EPICS_THREAD_OPTS_INIT;
+        opts.priority         = epicsThreadPriorityMedium;
+        opts.stackSize        = epicsThreadGetStackSize(epicsThreadStackMedium);
+        opts.joinable         = 1; // joined in ~adsAsynPortDriver()
+        dataCallbackThreadId_ = epicsThreadCreateOpt("adsAsynPortDriverDataCallbackThread",
+                                                     (EPICSTHREADFUNC)::dataCallbackThread,
+                                                     this,
+                                                     &opts);
+    }
+    if (dataCallbackThreadId_ == NULL)
     {
         printf("%s:%s: epicsThreadCreate failure\n", driverName, functionName);
         return;
     }
 
     //* Create the thread that does I/O Intr callback triggers */
-    status = (asynStatus)(epicsThreadCreate("adsAsynPortDriverTriggerEpicsIoIntrCallbacksThread",
-                                            epicsThreadPriorityHigh,
-                                            epicsThreadGetStackSize(epicsThreadStackMedium),
-                                            (EPICSTHREADFUNC)::triggerEpicsIoIntrCallbacksThread,
-                                            this) == NULL);
-    if (status)
+    {
+        epicsThreadOpts opts = EPICS_THREAD_OPTS_INIT;
+        opts.priority        = epicsThreadPriorityHigh;
+        opts.stackSize       = epicsThreadGetStackSize(epicsThreadStackMedium);
+        opts.joinable        = 1; // joined in ~adsAsynPortDriver()
+        triggerIoIntrThreadId_ =
+            epicsThreadCreateOpt("adsAsynPortDriverTriggerEpicsIoIntrCallbacksThread",
+                                 (EPICSTHREADFUNC)::triggerEpicsIoIntrCallbacksThread,
+                                 this,
+                                 &opts);
+    }
+    if (triggerIoIntrThreadId_ == NULL)
     {
         throw std::runtime_error(string_format(
             "%s:%s: epicsThreadCreate failure for TriggerEpicsIoIntrCallbacksThread.\n",
@@ -1270,14 +1284,51 @@ adsAsynPortDriver::~adsAsynPortDriver()
     const char* functionName = "~adsAsynPortDriver";
     asynPrint(pasynUserSelf, ASYN_TRACE_FLOW, "%s:%s:\n", driverName, functionName);
 
+    // Stop and join the worker threads BEFORE releasing symbolic handles,
+    // freeing adsParamArray_ or closing the ADS port. The cyclic and bulk-read
+    // threads issue synchronous ADS requests on the shared AmsRouter; if they
+    // are still running while this destructor does the same and frees their
+    // data, teardown either hangs (all threads blocked in AmsResponse::Wait) or
+    // crashes (use-after-free on adsParamArray_/amsPortList_).
+    stopThreads_ = true;
+    if (cyclicThreadId_)
+    {
+        epicsThreadMustJoin(cyclicThreadId_);
+        cyclicThreadId_ = nullptr;
+    }
+    if (bulkReadThreadId_)
+    {
+        epicsThreadMustJoin(bulkReadThreadId_);
+        bulkReadThreadId_ = nullptr;
+    }
+    if (dataCallbackThreadId_)
+    {
+        epicsThreadMustJoin(dataCallbackThreadId_);
+        dataCallbackThreadId_ = nullptr;
+    }
+    if (triggerIoIntrThreadId_)
+    {
+        epicsThreadMustJoin(triggerIoIntrThreadId_);
+        triggerIoIntrThreadId_ = nullptr;
+    }
+
     free(ipaddr_);
     free(amsaddr_);
 
     // Only default ams client port remains so we use that to delete the ads callbacks and release symbolic handles.
     for (int i = 0; i < adsParamArrayCount_; i++)
     {
-        adsDelDataCallback(adsPort_, &adsParamArray_[i], true);       //Block error messages
-        adsReleaseSymbolicHandle(adsPort_, &adsParamArray_[i], true); //Block error messages
+        // Only release PLC-side notifications/handles while still connected. On
+        // a dropped connection TwinCAT already discards this connection's
+        // handles and notifications (the driver re-acquires them on reconnect
+        // in refreshParams), and a synchronous ADS release would otherwise block
+        // up to adsTimeoutMS per param. Matches the connectedAds_ guard in
+        // refreshParams(). The free()s below must run regardless.
+        if (connectedAds_)
+        {
+            adsDelDataCallback(adsPort_, &adsParamArray_[i], true);       //Block error messages
+            adsReleaseSymbolicHandle(adsPort_, &adsParamArray_[i], true); //Block error messages
+        }
         free(adsParamArray_[i].recordName);
         free(adsParamArray_[i].recordType);
         free(adsParamArray_[i].scan);
@@ -1330,6 +1381,10 @@ void adsAsynPortDriver::cyclicThread()
                   sampleTime);
 
         epicsThreadSleep(sampleTime);
+        if (stopThreads_)
+        {
+            break; // driver is being destroyed — exit before issuing ADS I/O
+        }
         if (!allowCallbackEpicsState)
         {
             continue; //Epics not started
@@ -1515,6 +1570,10 @@ void adsAsynPortDriver::bulkReadThread()
     }
     while (1)
     {
+        if (stopThreads_)
+        {
+            break; // driver is being destroyed — stop polling
+        }
         {
             std::lock_guard<std::mutex> lg(bulkReadInfoMutex_);
             gettimeofday(&start, NULL);
@@ -1624,6 +1683,10 @@ void adsAsynPortDriver::dataCallbackThread()
     asynPrint(pasynUserSelf, ASYN_TRACE_FLOW, "%s:%s:\n", driverName, functionName);
     while (1)
     {
+        if (stopThreads_)
+        {
+            break; // driver is being destroyed
+        }
         if (datacbqueue.empty() || !allowCallbackEpicsState)
         {
             usleep(10000);
@@ -1658,6 +1721,10 @@ void adsAsynPortDriver::triggerEpicsIoIntrCallbacksThread()
     asynPrint(pasynUserSelf, ASYN_TRACE_FLOW, "%s:%s:\n", driverName, __func__);
     while (true)
     {
+        if (stopThreads_)
+        {
+            break; // driver is being destroyed
+        }
         if (!allowCallbackEpicsState)
         {
             epicsThreadSleep(0.5);

--- a/adsApp/src/adsAsynPortDriver.cpp
+++ b/adsApp/src/adsAsynPortDriver.cpp
@@ -5840,6 +5840,16 @@ asynStatus adsAsynPortDriver::adsWriteParam(uint16_t amsClientPort,
     const char* functionName = "adsWriteParam";
     asynPrint(pasynUserSelf, ASYN_TRACE_FLOW, "%s:%s:\n", driverName, functionName);
 
+    // Reject I/O once teardown has begun. The destructor sets stopThreads_ and
+    // then frees each paramInfo (plcAdrStr, buffers); a straggler record-scan
+    // callback reaching this far would dereference freed memory. Bail before
+    // touching paramInfo. In a live IOC the driver outlives the process, so
+    // this only fires in the unit-test harness, which deletes the driver.
+    if (stopThreads_)
+    {
+        return asynError;
+    }
+
     // Calculate consumed time by this method
     struct timeval start, end;
     long secs_used, micros_used;
@@ -5962,6 +5972,14 @@ asynStatus adsAsynPortDriver::adsReadParam(uint16_t amsClientPort,
     uint32_t group  = 0;
     uint32_t offset = 0;
     *error          = 0;
+
+    // Reject I/O once teardown has begun (see adsWriteParam for the rationale):
+    // the destructor frees paramInfo after setting stopThreads_, so a straggler
+    // scan callback must bail before dereferencing freed memory.
+    if (stopThreads_)
+    {
+        return asynError;
+    }
 
     AmsAddr amsServer;
     amsServer = {remoteNetId_, paramInfo->amsPort};

--- a/adsApp/src/adsAsynPortDriver.h
+++ b/adsApp/src/adsAsynPortDriver.h
@@ -12,6 +12,7 @@
 #include "adsSymbolTable.h"
 #include <mutex>
 #include <queue>
+#include <atomic>
 
 /** Class derived of asynPortDriver for ads communication with TwinCAT plc:s */
 
@@ -241,6 +242,18 @@ class adsAsynPortDriver : public asynPortDriver
     ADSTIMESOURCE defaultTimeSource_;
     std::unordered_map<epicsThreadId, AmsClientPortEntry> threadIdToAmsClientPortMap_;
     std::recursive_mutex threadIdToAmsClientPortMapMutex_;
+
+    // Worker-thread lifecycle
+    // Cooperative shutdown so the destructor can stop and join the worker
+    // threads before releasing handles / freeing adsParamArray_ / closing the
+    // ADS port. Without this, the still-running cyclic/bulk threads race the
+    // destructor on the shared AmsRouter (teardown hang) or it frees memory out
+    // from under them (use-after-free crash).
+    std::atomic<bool> stopThreads_{false};
+    epicsThreadId cyclicThreadId_{nullptr};
+    epicsThreadId bulkReadThreadId_{nullptr};
+    epicsThreadId dataCallbackThreadId_{nullptr};
+    epicsThreadId triggerIoIntrThreadId_{nullptr};
     std::unordered_map<std::string, int> createdParamsMap_;
     std::mutex bulkReadInfoMutex_;
     std::queue<adsParamInfo*> arrayParamsToCallCallbacksFor_;
@@ -282,14 +295,6 @@ class adsAsynPortDriver : public asynPortDriver
   public:
     int bulkOK;          // OK to process bulk reads!
     int bulk_elapsed_us; // Time of last bulk read loop.
-
-    /** Symbol-table cache, one SymbolMap per AMS port.
-    *  Key:   AMS port number (e.g. 851).
-       *  Value: unordered_map<lowercase_symbol_name, AdsSymbolInfo>.
-       *  Populated by adsLoadSymbolTable(), read by adsGetSymInfoByName().
-       *  Cleared by adsInvalidateSymbolCache() in invalidateParams().   */
-    //     SymbolCache symbolCache_;
-
 
     // member declarations
     std::unordered_map<std::string, AdsSymbolDictEntry> symbolDict_;


### PR DESCRIPTION
# Driver teardown: stop/join worker threads + release symbolic handles on clean exit
The issues in this PR surfaced during experimentation with the GTEST suite and are a preparation for another PR that will include a CI-runnable GTEST suite.

1. `Stop and join worker threads before destroying the driver.`
2. `Release symbolic handles on clean IOC exit.`

Touches only `adsApp/src/adsAsynPortDriver.{cpp,h}`.

## 1. Stop/join worker threads before destruction

`~adsAsynPortDriver()` released handles, freed `adsParamArray_`, deleted `amsPortList_` and closed the ADS port while its four worker threads were still running (created detached, infinite loops, no stop path). Destruction raced them:

- **Hang:** `cyclicThread`/`bulkReadThread` keep issuing synchronous ADS requests on the same shared `AmsRouter` the destructor uses to release handles → every party blocks in `AmsResponse::Wait`, teardown never completes.
- **Crash:** the destructor frees `adsParamArray_`/`amsPortList_` under a live thread -> `malloc_consolidate(): unaligned fastbin chunk` / SIGSEGV.

**Fix cooperative shutdown:** `std::atomic<bool> stopThreads_` that each loop checks; threads created joinable (`epicsThreadCreateOpt`) with stored ids; destructor sets `stopThreads_`, `epicsThreadMustJoin()`s all four, *then* releases/frees/closes. The per-param ADS release is guarded by `connectedAds_` (matches `refreshParams()`), so deleting while the PLC is unreachable skips the synchronous I/O instead of blocking `adsTimeoutMS` per param.

Includes the completing detail: `bulkReadThread` now honours `stopThreads_` while it waits for the first bulk-read setup (`while (!bulkOK)`); without it, a driver torn down before `bulkOK` is ever set (e.g., instantiated with no bulk params) leaves that thread spinning forever, and the join never returns.

## 2. Release symbolic handles on clean IOC exit

The driver is never deleted in a normal IOC, so on a clean shutdown (`iocsh exit` / Ctrl-D -> `epicsExit`), its symbolic handles and device notifications were abandoned with the AMS connection still up. TwinCAT does not reclaim them on connection close, so each IOC restart leaks PLC router memory until the next configuration download.

**Fix:** an `epicsAtExit` handler runs the existing teardown (stop/join threads -> `SYM_RELEASEHND`/delete notifications -> close port), factored into an idempotent `cleanupAdsConnection()` shared with the destructor (guarded by `shutdownDone_`), resolving the instance via the file-static `adsAsynPortObj` (nulled in the destructor) so it never touches a freed object.

Measured on a real PLC: a clean Ctrl-D exit returns the router to baseline (e.g., 128.6 KB -> 111.5 KB on a 32 MB router), confirming the handles are live state that `SYM_RELEASEHND` fully reclaims.

## Scope/risk

These are **latent-defect / correctness** fixes, not a current production crash: production IOCs never reach `~adsAsynPortDriver()` (the driver is leaked for the process lifetime; procServ kills the process; the comms-loss path calls `exit(-1)`), and on the constrained PLCs we run (32 MB BSD router) router exhaustion is practically unreachable because PLC config activations reset it long before then. Fix 2 only covers the clean-exit path (Ctrl-D / iocsh `exit`), **not** procServ SIGKILL / Ctrl-C / comms-loss exit. A SIGTERM/SIGINT->`epicsExit` handler to cover those was deliberately **deferred**; it would require procServ on a catchable signal and addresses a case that does not realistically occur.

The value enables clean, deliberate teardown, port reconfiguration, and leak checking, and ensures clean shutdowns return their router memory.

## Testing

The handle-release memory reclaim (Fix 2) was validated on hardware by observing the BSD PLC router memory before and after a session: starting the IOC and then killing it with Ctrl-D returned the router to its baseline, confirming the symbolic handles are reclaimed on clean exit. Additionally validated against a GoogleTest lifecycle suite + pyads test server (developed on the `unittests` branch, a separate PR): , including a `delete driver` clean-shutdown assertion that previously hung/crashed. 

## Follow-ups (intentionally not in this PR)

1. Batch handle release via `SUMUP_WRITE (0xF081) `. Handles are acquired in one batched `SUMUP_READWRITE ` telegram but released one at a time in `cleanupAdsConnection() `, O(N) roundtrips on teardown. Collapsing into a single SUMUP_WRITE telegram would make release as cheap as acquire. Deferred because clean-exit teardown is a rarely hit path and seconds-scale latency there is tolerable.

2. SIGTERM/SIGINT -> epicsExit() handler for production teardown. Production IOCs are killed by  `procServ (default: SIGKILL) `, which bypasses the destructor and epicsAtExit chain entirely, so the handle release in item 1 never fires in prod. A catchable-signal handler routing through  `epicsExit() ` would fix this, but requires procServ to be configured to send SIGTERM rather than SIGKILL. Deferred because router handle exhaustion is practically unreachable on our PLCs (32 MB BSD router, config-activation resets). Note the two items compose: the signal handler only pays off if release is also cheap (item 1)

.


